### PR TITLE
Topic/ada lexer

### DIFF
--- a/src/main/control/com/adacore/adaintellij/lexanalysis/AdaLexer.java
+++ b/src/main/control/com/adacore/adaintellij/lexanalysis/AdaLexer.java
@@ -831,6 +831,20 @@ public final class AdaLexer extends LexerBase {
 		// The next character to be analysed
 		char nextCharacter = text.charAt(lexingOffset);
 		
+		// If the next character is an apostrophe and the last token
+		// was an identifier, then immediately mark this token as an
+		// apostrophe token and return
+		
+		if (nextCharacter == '\'' && tokenType == AdaTokenTypes.IDENTIFIER) {
+			
+			lexingOffset = tokenEnd = tokenStart + 1;
+			
+			tokenType = AdaTokenTypes.APOSTROPHE;
+			
+			return;
+		
+		}
+		
 		// While the next token has not been determined...
 		
 		characterLoop: // label only used for reference in comments

--- a/src/main/control/com/adacore/adaintellij/lexanalysis/AdaLexer.java
+++ b/src/main/control/com/adacore/adaintellij/lexanalysis/AdaLexer.java
@@ -22,19 +22,19 @@ public final class AdaLexer extends LexerBase {
 	/**
 	 * Regexes matching different whitespace characters.
 	 */
-	private static final OORegex HORIZONTAL_TABULATION_REGEX = new UnitRegex("\t");
-	private static final OORegex LINE_FEED_REGEX             = new UnitRegex("\n");
-	private static final OORegex VERTICAL_TABULATION_REGEX   = new UnitRegex("\u000b");
-	private static final OORegex FORM_FEED_REGEX             = new UnitRegex("\f");
-	private static final OORegex CARRIAGE_RETURN_REGEX       = new UnitRegex("\r");
-	private static final OORegex SPACE_REGEX                 = new UnitRegex("\u0020");
-	private static final OORegex NEXT_LINE_REGEX             = new UnitRegex("\u0085");
-	private static final OORegex NO_BREAK_SPACE_REGEX        = new UnitRegex("\u00a0");
+	private static final LexerRegex HORIZONTAL_TABULATION_REGEX = new UnitRegex("\t");
+	private static final LexerRegex LINE_FEED_REGEX             = new UnitRegex("\n");
+	private static final LexerRegex VERTICAL_TABULATION_REGEX   = new UnitRegex("\u000b");
+	private static final LexerRegex FORM_FEED_REGEX             = new UnitRegex("\f");
+	private static final LexerRegex CARRIAGE_RETURN_REGEX       = new UnitRegex("\r");
+	private static final LexerRegex SPACE_REGEX                 = new UnitRegex("\u0020");
+	private static final LexerRegex NEXT_LINE_REGEX             = new UnitRegex("\u0085");
+	private static final LexerRegex NO_BREAK_SPACE_REGEX        = new UnitRegex("\u00a0");
 	
 	/**
 	 * Regex defining a sequence of whitespaces in Ada.
 	 */
-	private static final OORegex WHITESPACES_REGEX =
+	private static final LexerRegex WHITESPACES_REGEX =
 		new OneOrMoreRegex(
 			UnionRegex.fromRegexes(
 				HORIZONTAL_TABULATION_REGEX,
@@ -53,36 +53,36 @@ public final class AdaLexer extends LexerBase {
 	/**
 	 * Unit regexes for matching Ada single delimiters.
 	 */
-	private static final OORegex AMPERSAND_REGEX         = new UnitRegex("&");
-	private static final OORegex APOSTROPHE_REGEX        = new UnitRegex("'");
-	private static final OORegex LEFT_PARENTHESIS_REGEX  = new UnitRegex("(");
-	private static final OORegex RIGHT_PARENTHESIS_REGEX = new UnitRegex(")");
-	private static final OORegex ASTERISK_REGEX          = new UnitRegex("*");
-	private static final OORegex PLUS_SIGN_REGEX         = new UnitRegex("+");
-	private static final OORegex COMMA_REGEX             = new UnitRegex(",");
-	private static final OORegex HYPHEN_MINUS_REGEX      = new UnitRegex("-");
-	private static final OORegex FULL_STOP_REGEX         = new UnitRegex(".");
-	private static final OORegex SOLIDUS_REGEX           = new UnitRegex("/");
-	private static final OORegex COLON_REGEX             = new UnitRegex(":");
-	private static final OORegex SEMICOLON_REGEX         = new UnitRegex(";");
-	private static final OORegex LESS_THAN_SIGN_REGEX    = new UnitRegex("<");
-	private static final OORegex EQUALS_SIGN_REGEX       = new UnitRegex("=");
-	private static final OORegex GREATER_THAN_SIGN_REGEX = new UnitRegex(">");
-	private static final OORegex VERTICAL_LINE_REGEX     = new UnitRegex("|");
+	private static final LexerRegex AMPERSAND_REGEX         = new UnitRegex("&");
+	private static final LexerRegex APOSTROPHE_REGEX        = new UnitRegex("'");
+	private static final LexerRegex LEFT_PARENTHESIS_REGEX  = new UnitRegex("(");
+	private static final LexerRegex RIGHT_PARENTHESIS_REGEX = new UnitRegex(")");
+	private static final LexerRegex ASTERISK_REGEX          = new UnitRegex("*");
+	private static final LexerRegex PLUS_SIGN_REGEX         = new UnitRegex("+");
+	private static final LexerRegex COMMA_REGEX             = new UnitRegex(",");
+	private static final LexerRegex HYPHEN_MINUS_REGEX      = new UnitRegex("-");
+	private static final LexerRegex FULL_STOP_REGEX         = new UnitRegex(".");
+	private static final LexerRegex SOLIDUS_REGEX           = new UnitRegex("/");
+	private static final LexerRegex COLON_REGEX             = new UnitRegex(":");
+	private static final LexerRegex SEMICOLON_REGEX         = new UnitRegex(";");
+	private static final LexerRegex LESS_THAN_SIGN_REGEX    = new UnitRegex("<");
+	private static final LexerRegex EQUALS_SIGN_REGEX       = new UnitRegex("=");
+	private static final LexerRegex GREATER_THAN_SIGN_REGEX = new UnitRegex(">");
+	private static final LexerRegex VERTICAL_LINE_REGEX     = new UnitRegex("|");
 	
 	/**
 	 * Unit regexes for matching Ada compound delimiters.
 	 */
-	private static final OORegex ARROW_REGEX               = new UnitRegex("=>");
-	private static final OORegex DOUBLE_DOT_REGEX          = new UnitRegex("..");
-	private static final OORegex DOUBLE_ASTERISK_REGEX     = new UnitRegex("**");
-	private static final OORegex ASSIGNMENT_REGEX          = new UnitRegex(":=");
-	private static final OORegex NOT_EQUAL_SIGN_REGEX      = new UnitRegex("/=");
-	private static final OORegex GREATER_EQUAL_SIGN_REGEX  = new UnitRegex(">=");
-	private static final OORegex LESS_EQUAL_SIGN_REGEX     = new UnitRegex("<=");
-	private static final OORegex LEFT_LABEL_BRACKET_REGEX  = new UnitRegex("<<");
-	private static final OORegex RIGHT_LABEL_BRACKET_REGEX = new UnitRegex(">>");
-	private static final OORegex BOX_SIGN_REGEX            = new UnitRegex("<>");
+	private static final LexerRegex ARROW_REGEX               = new UnitRegex("=>");
+	private static final LexerRegex DOUBLE_DOT_REGEX          = new UnitRegex("..");
+	private static final LexerRegex DOUBLE_ASTERISK_REGEX     = new UnitRegex("**");
+	private static final LexerRegex ASSIGNMENT_REGEX          = new UnitRegex(":=");
+	private static final LexerRegex NOT_EQUAL_SIGN_REGEX      = new UnitRegex("/=");
+	private static final LexerRegex GREATER_EQUAL_SIGN_REGEX  = new UnitRegex(">=");
+	private static final LexerRegex LESS_EQUAL_SIGN_REGEX     = new UnitRegex("<=");
+	private static final LexerRegex LEFT_LABEL_BRACKET_REGEX  = new UnitRegex("<<");
+	private static final LexerRegex RIGHT_LABEL_BRACKET_REGEX = new UnitRegex(">>");
+	private static final LexerRegex BOX_SIGN_REGEX            = new UnitRegex("<>");
 	
 	// Character Categories
 	
@@ -90,28 +90,28 @@ public final class AdaLexer extends LexerBase {
 	 * Regexes matching characters based on their "General Category"
 	 * as defined by the Unicode standard.
 	 */
-	private static final OORegex LETTER_UPPERCASE_REGEX       = new GeneralCategoryRegex("Lu");
-	private static final OORegex LETTER_LOWERCASE_REGEX       = new GeneralCategoryRegex("Ll");
-	private static final OORegex LETTER_TITLECASE_REGEX       = new GeneralCategoryRegex("Lt");
-	private static final OORegex LETTER_MODIFIER_REGEX        = new GeneralCategoryRegex("Lm");
-	private static final OORegex LETTER_OTHER_REGEX           = new GeneralCategoryRegex("Lo");
-	private static final OORegex MARK_NON_SPACING_REGEX       = new GeneralCategoryRegex("Mn");
-	private static final OORegex MARK_SPACING_COMBINING_REGEX = new GeneralCategoryRegex("Mc");
-	private static final OORegex NUMBER_DECIMAL_REGEX         = new GeneralCategoryRegex("Nd");
-	private static final OORegex NUMBER_LETTER_REGEX          = new GeneralCategoryRegex("Nl");
-	private static final OORegex PUNCTUATION_CONNECTOR_REGEX  = new GeneralCategoryRegex("Pc");
-	private static final OORegex OTHER_FORMAT_REGEX           = new GeneralCategoryRegex("Cf"); // Currently not used
-	private static final OORegex SEPARATOR_SPACE_REGEX        = new GeneralCategoryRegex("Zs"); // Currently not used
-	private static final OORegex SEPARATOR_LINE_REGEX         = new GeneralCategoryRegex("Zl");
-	private static final OORegex SEPARATOR_PARAGRAPH_REGEX    = new GeneralCategoryRegex("Zp");
-	private static final OORegex OTHER_PRIVATE_USE_REGEX      = new GeneralCategoryRegex("Co");
-	private static final OORegex OTHER_SURROGATE_REGEX        = new GeneralCategoryRegex("Cs");
+	private static final LexerRegex LETTER_UPPERCASE_REGEX       = new GeneralCategoryRegex("Lu");
+	private static final LexerRegex LETTER_LOWERCASE_REGEX       = new GeneralCategoryRegex("Ll");
+	private static final LexerRegex LETTER_TITLECASE_REGEX       = new GeneralCategoryRegex("Lt");
+	private static final LexerRegex LETTER_MODIFIER_REGEX        = new GeneralCategoryRegex("Lm");
+	private static final LexerRegex LETTER_OTHER_REGEX           = new GeneralCategoryRegex("Lo");
+	private static final LexerRegex MARK_NON_SPACING_REGEX       = new GeneralCategoryRegex("Mn");
+	private static final LexerRegex MARK_SPACING_COMBINING_REGEX = new GeneralCategoryRegex("Mc");
+	private static final LexerRegex NUMBER_DECIMAL_REGEX         = new GeneralCategoryRegex("Nd");
+	private static final LexerRegex NUMBER_LETTER_REGEX          = new GeneralCategoryRegex("Nl");
+	private static final LexerRegex PUNCTUATION_CONNECTOR_REGEX  = new GeneralCategoryRegex("Pc");
+	private static final LexerRegex OTHER_FORMAT_REGEX           = new GeneralCategoryRegex("Cf"); // Currently not used
+	private static final LexerRegex SEPARATOR_SPACE_REGEX        = new GeneralCategoryRegex("Zs"); // Currently not used
+	private static final LexerRegex SEPARATOR_LINE_REGEX         = new GeneralCategoryRegex("Zl");
+	private static final LexerRegex SEPARATOR_PARAGRAPH_REGEX    = new GeneralCategoryRegex("Zp");
+	private static final LexerRegex OTHER_PRIVATE_USE_REGEX      = new GeneralCategoryRegex("Co");
+	private static final LexerRegex OTHER_SURROGATE_REGEX        = new GeneralCategoryRegex("Cs");
 	
 	/**
 	 * Regexes matching various character classes defined by
 	 * the Ada 2012 specification.
 	 */
-	private static final OORegex FORMAT_EFFECTOR_REGEX =
+	private static final LexerRegex FORMAT_EFFECTOR_REGEX =
 		UnionRegex.fromRegexes(
 			HORIZONTAL_TABULATION_REGEX,
 			LINE_FEED_REGEX,
@@ -123,13 +123,13 @@ public final class AdaLexer extends LexerBase {
 			SEPARATOR_PARAGRAPH_REGEX
 		);
 	
-	private static final OORegex OTHER_CONTROL_REGEX =
+	private static final LexerRegex OTHER_CONTROL_REGEX =
 		new IntersectionRegex(
 			new GeneralCategoryRegex("Cc"),
 			new NotRegex(FORMAT_EFFECTOR_REGEX)
 		);
 	
-	private static final OORegex GRAPHIC_CHARACTER_REGEX =
+	private static final LexerRegex GRAPHIC_CHARACTER_REGEX =
 		new NotRegex(
 			UnionRegex.fromRegexes(
 				OTHER_CONTROL_REGEX,
@@ -154,7 +154,7 @@ public final class AdaLexer extends LexerBase {
 	 *   | letter_other
 	 *   | number_letter
 	 */
-	private static final OORegex IDENTIFIER_START_REGEX =
+	private static final LexerRegex IDENTIFIER_START_REGEX =
 		UnionRegex.fromRegexes(
 			LETTER_UPPERCASE_REGEX,
 			LETTER_LOWERCASE_REGEX,
@@ -174,7 +174,7 @@ public final class AdaLexer extends LexerBase {
 	 *   | number_decimal
 	 *   | punctuation_connector
 	 */
-	private static final OORegex IDENTIFIER_EXTEND_REGEX =
+	private static final LexerRegex IDENTIFIER_EXTEND_REGEX =
 		UnionRegex.fromRegexes(
 			MARK_NON_SPACING_REGEX,
 			MARK_SPACING_COMBINING_REGEX,
@@ -188,8 +188,8 @@ public final class AdaLexer extends LexerBase {
 	 * identifier ::=
 	 *     identifier_start {identifier_start | identifier_extend}
 	 */
-	private static final OORegex IDENTIFIER_REGEX =
-		new ConcatRegex(
+	private static final LexerRegex IDENTIFIER_REGEX =
+		new ConcatenationRegex(
 			IDENTIFIER_START_REGEX,
 			new ZeroOrMoreRegex(
 				new UnionRegex(
@@ -206,18 +206,18 @@ public final class AdaLexer extends LexerBase {
 	 *
 	 * digit ::= 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9
 	 */
-	private static final OORegex DIGIT_REGEX = UnionRegex.fromRange('0', '9');
+	private static final LexerRegex DIGIT_REGEX = UnionRegex.fromRange('0', '9');
 	
 	/**
 	 * Regex defining a numeral (used to define numeric literals).
 	 *
 	 * numeral ::= digit {[underline] digit}
 	 */
-	private static final OORegex NUMERAL_REGEX =
-		new ConcatRegex(
+	private static final LexerRegex NUMERAL_REGEX =
+		new ConcatenationRegex(
 			DIGIT_REGEX,
 			new ZeroOrMoreRegex(
-				new ConcatRegex(
+				new ConcatenationRegex(
 					new ZeroOrOneRegex(new UnitRegex("_")),
 					DIGIT_REGEX
 				)
@@ -229,8 +229,8 @@ public final class AdaLexer extends LexerBase {
 	 *
 	 * exponent ::= e [+] numeral | e – numeral
 	 */
-	private static final OORegex EXPONENT_REGEX =
-		ConcatRegex.fromRegexes(
+	private static final LexerRegex EXPONENT_REGEX =
+		ConcatenationRegex.fromRegexes(
 			new UnitRegex("e"),
 			UnionRegex.fromRegexes(
 				new UnitRegex("-"),
@@ -246,11 +246,11 @@ public final class AdaLexer extends LexerBase {
 	 *
 	 * decimal_literal ::= numeral [.numeral] [exponent]
 	 */
-	private static final OORegex DECIMAL_LITERAL_REGEX =
-		ConcatRegex.fromRegexes(
+	private static final LexerRegex DECIMAL_LITERAL_REGEX =
+		ConcatenationRegex.fromRegexes(
 			NUMERAL_REGEX,
 			new ZeroOrOneRegex(
-				new ConcatRegex(
+				new ConcatenationRegex(
 					new UnitRegex("."),
 					NUMERAL_REGEX
 				)
@@ -265,14 +265,14 @@ public final class AdaLexer extends LexerBase {
 	 *
 	 * base ::= numeral
 	 */
-	private static final OORegex BASE_REGEX = NUMERAL_REGEX;
+	private static final LexerRegex BASE_REGEX = NUMERAL_REGEX;
 	
 	/**
 	 * Regex defining an extended digit (hexadecimal digit).
 	 *
 	 * extended_digit ::= digit | a | b | c | d | e | f
 	 */
-	private static final OORegex EXTENDED_DIGIT_REGEX =
+	private static final LexerRegex EXTENDED_DIGIT_REGEX =
 		UnionRegex.fromRegexes(
 			DIGIT_REGEX,
 			new UnitRegex("a"),
@@ -289,11 +289,11 @@ public final class AdaLexer extends LexerBase {
 	 * based_numeral ::=
 	 *     extended_digit {[underline] extended_digit}
 	 */
-	private static final OORegex BASED_NUMERAL_REGEX =
-		new ConcatRegex(
+	private static final LexerRegex BASED_NUMERAL_REGEX =
+		new ConcatenationRegex(
 			EXTENDED_DIGIT_REGEX,
 			new ZeroOrMoreRegex(
-				new ConcatRegex(
+				new ConcatenationRegex(
 					new ZeroOrOneRegex(new UnitRegex("_")),
 					EXTENDED_DIGIT_REGEX
 				)
@@ -306,13 +306,13 @@ public final class AdaLexer extends LexerBase {
 	 * based_literal ::=
 	 *     base # based_numeral [.based_numeral] # [exponent]
 	 */
-	private static final OORegex BASED_LITERAL_REGEX =
-		ConcatRegex.fromRegexes(
+	private static final LexerRegex BASED_LITERAL_REGEX =
+		ConcatenationRegex.fromRegexes(
 			BASE_REGEX,
 			new UnitRegex("#"),
 			BASED_NUMERAL_REGEX,
 			new ZeroOrOneRegex(
-				new ConcatRegex(
+				new ConcatenationRegex(
 					new UnitRegex("."),
 					BASED_NUMERAL_REGEX
 				)
@@ -328,8 +328,8 @@ public final class AdaLexer extends LexerBase {
 	 *
 	 * character_literal ::= 'graphic_character'
 	 */
-	private static final OORegex CHARACTER_LITERAL_REGEX =
-		ConcatRegex.fromRegexes(
+	private static final LexerRegex CHARACTER_LITERAL_REGEX =
+		ConcatenationRegex.fromRegexes(
 			new UnitRegex("'"),
 			GRAPHIC_CHARACTER_REGEX,
 			new UnitRegex("'")
@@ -344,7 +344,7 @@ public final class AdaLexer extends LexerBase {
 	 * A non-quotation-mark graphic character is defined as any
 	 * graphic_character other than the quotation mark character '"'
 	 */
-	private static final OORegex NON_QUOTATION_MARK_GRAPHIC_CHARACTER_REGEX =
+	private static final LexerRegex NON_QUOTATION_MARK_GRAPHIC_CHARACTER_REGEX =
 		new IntersectionRegex(
 			GRAPHIC_CHARACTER_REGEX,
 			new NotRegex(new UnitRegex("\""))
@@ -355,7 +355,7 @@ public final class AdaLexer extends LexerBase {
 	 *
 	 * string_element ::= "" | non_quotation_mark_graphic_character
 	 */
-	private static final OORegex STRING_ELEMENT_REGEX =
+	private static final LexerRegex STRING_ELEMENT_REGEX =
 		new UnionRegex(
 			new UnitRegex("\"\""),
 			NON_QUOTATION_MARK_GRAPHIC_CHARACTER_REGEX
@@ -366,8 +366,8 @@ public final class AdaLexer extends LexerBase {
 	 *
 	 * string_literal ::= "{string_element}"
 	 */
-	private static final OORegex STRING_LITERAL_REGEX =
-		ConcatRegex.fromRegexes(
+	private static final LexerRegex STRING_LITERAL_REGEX =
+		ConcatenationRegex.fromRegexes(
 			new UnitRegex("\""),
 			new ZeroOrMoreRegex(STRING_ELEMENT_REGEX),
 			new UnitRegex("\"")
@@ -378,7 +378,7 @@ public final class AdaLexer extends LexerBase {
 	/**
 	 * Regex defining a non-end-of-line character (useed to define comments).
 	 */
-	private static final OORegex NON_END_OF_LINE_CHARACTER_REGEX =
+	private static final LexerRegex NON_END_OF_LINE_CHARACTER_REGEX =
 		new NotRegex(
 			UnionRegex.fromRegexes(
 				LINE_FEED_REGEX,
@@ -396,8 +396,8 @@ public final class AdaLexer extends LexerBase {
 	 *
 	 * comment ::= --{non_end_of_line_character}
 	 */
-	private static final OORegex COMMENT_REGEX =
-		ConcatRegex.fromRegexes(
+	private static final LexerRegex COMMENT_REGEX =
+		ConcatenationRegex.fromRegexes(
 			new UnitRegex("--"),
 			new ZeroOrMoreRegex(NON_END_OF_LINE_CHARACTER_REGEX)
 		);
@@ -407,97 +407,97 @@ public final class AdaLexer extends LexerBase {
 	/**
 	 * Unit regexes for matching Ada keywords.
 	 */
-	private static final OORegex ABORT_KEYWORD_REGEX        = new UnitRegex("abort"       , 1);
-	private static final OORegex ABS_KEYWORD_REGEX          = new UnitRegex("abs"         , 1);
-	private static final OORegex ABSTRACT_KEYWORD_REGEX     = new UnitRegex("abstract"    , 1);
-	private static final OORegex ACCEPT_KEYWORD_REGEX       = new UnitRegex("accept"      , 1);
-	private static final OORegex ACCESS_KEYWORD_REGEX       = new UnitRegex("access"      , 1);
-	private static final OORegex ALIASED_KEYWORD_REGEX      = new UnitRegex("aliased"     , 1);
-	private static final OORegex ALL_KEYWORD_REGEX          = new UnitRegex("all"         , 1);
-	private static final OORegex AND_KEYWORD_REGEX          = new UnitRegex("and"         , 1);
-	private static final OORegex ARRAY_KEYWORD_REGEX        = new UnitRegex("array"       , 1);
-	private static final OORegex AT_KEYWORD_REGEX           = new UnitRegex("at"          , 1);
+	private static final LexerRegex ABORT_KEYWORD_REGEX        = new UnitRegex("abort"       , 1);
+	private static final LexerRegex ABS_KEYWORD_REGEX          = new UnitRegex("abs"         , 1);
+	private static final LexerRegex ABSTRACT_KEYWORD_REGEX     = new UnitRegex("abstract"    , 1);
+	private static final LexerRegex ACCEPT_KEYWORD_REGEX       = new UnitRegex("accept"      , 1);
+	private static final LexerRegex ACCESS_KEYWORD_REGEX       = new UnitRegex("access"      , 1);
+	private static final LexerRegex ALIASED_KEYWORD_REGEX      = new UnitRegex("aliased"     , 1);
+	private static final LexerRegex ALL_KEYWORD_REGEX          = new UnitRegex("all"         , 1);
+	private static final LexerRegex AND_KEYWORD_REGEX          = new UnitRegex("and"         , 1);
+	private static final LexerRegex ARRAY_KEYWORD_REGEX        = new UnitRegex("array"       , 1);
+	private static final LexerRegex AT_KEYWORD_REGEX           = new UnitRegex("at"          , 1);
 	
-	private static final OORegex BEGIN_KEYWORD_REGEX        = new UnitRegex("begin"       , 1);
-	private static final OORegex BODY_KEYWORD_REGEX         = new UnitRegex("body"        , 1);
+	private static final LexerRegex BEGIN_KEYWORD_REGEX        = new UnitRegex("begin"       , 1);
+	private static final LexerRegex BODY_KEYWORD_REGEX         = new UnitRegex("body"        , 1);
 	
-	private static final OORegex CASE_KEYWORD_REGEX         = new UnitRegex("case"        , 1);
-	private static final OORegex CONSTANT_KEYWORD_REGEX     = new UnitRegex("constant"    , 1);
+	private static final LexerRegex CASE_KEYWORD_REGEX         = new UnitRegex("case"        , 1);
+	private static final LexerRegex CONSTANT_KEYWORD_REGEX     = new UnitRegex("constant"    , 1);
 	
-	private static final OORegex DECLARE_KEYWORD_REGEX      = new UnitRegex("declare"     , 1);
-	private static final OORegex DELAY_KEYWORD_REGEX        = new UnitRegex("delay"       , 1);
-	private static final OORegex DELTA_KEYWORD_REGEX        = new UnitRegex("delta"       , 1);
-	private static final OORegex DIGITS_KEYWORD_REGEX       = new UnitRegex("digits"      , 1);
-	private static final OORegex DO_KEYWORD_REGEX           = new UnitRegex("do"          , 1);
+	private static final LexerRegex DECLARE_KEYWORD_REGEX      = new UnitRegex("declare"     , 1);
+	private static final LexerRegex DELAY_KEYWORD_REGEX        = new UnitRegex("delay"       , 1);
+	private static final LexerRegex DELTA_KEYWORD_REGEX        = new UnitRegex("delta"       , 1);
+	private static final LexerRegex DIGITS_KEYWORD_REGEX       = new UnitRegex("digits"      , 1);
+	private static final LexerRegex DO_KEYWORD_REGEX           = new UnitRegex("do"          , 1);
 	
-	private static final OORegex ELSE_KEYWORD_REGEX         = new UnitRegex("else"        , 1);
-	private static final OORegex ELSIF_KEYWORD_REGEX        = new UnitRegex("elsif"       , 1);
-	private static final OORegex END_KEYWORD_REGEX          = new UnitRegex("end"         , 1);
-	private static final OORegex ENTRY_KEYWORD_REGEX        = new UnitRegex("entry"       , 1);
-	private static final OORegex EXCEPTION_KEYWORD_REGEX    = new UnitRegex("exception"   , 1);
-	private static final OORegex EXIT_KEYWORD_REGEX         = new UnitRegex("exit"        , 1);
+	private static final LexerRegex ELSE_KEYWORD_REGEX         = new UnitRegex("else"        , 1);
+	private static final LexerRegex ELSIF_KEYWORD_REGEX        = new UnitRegex("elsif"       , 1);
+	private static final LexerRegex END_KEYWORD_REGEX          = new UnitRegex("end"         , 1);
+	private static final LexerRegex ENTRY_KEYWORD_REGEX        = new UnitRegex("entry"       , 1);
+	private static final LexerRegex EXCEPTION_KEYWORD_REGEX    = new UnitRegex("exception"   , 1);
+	private static final LexerRegex EXIT_KEYWORD_REGEX         = new UnitRegex("exit"        , 1);
 	
-	private static final OORegex FOR_KEYWORD_REGEX          = new UnitRegex("for"         , 1);
-	private static final OORegex FUNCTION_KEYWORD_REGEX     = new UnitRegex("function"    , 1);
+	private static final LexerRegex FOR_KEYWORD_REGEX          = new UnitRegex("for"         , 1);
+	private static final LexerRegex FUNCTION_KEYWORD_REGEX     = new UnitRegex("function"    , 1);
 	
-	private static final OORegex GENERIC_KEYWORD_REGEX      = new UnitRegex("generic"     , 1);
-	private static final OORegex GOTO_KEYWORD_REGEX         = new UnitRegex("goto"        , 1);
+	private static final LexerRegex GENERIC_KEYWORD_REGEX      = new UnitRegex("generic"     , 1);
+	private static final LexerRegex GOTO_KEYWORD_REGEX         = new UnitRegex("goto"        , 1);
 	
-	private static final OORegex IF_KEYWORD_REGEX           = new UnitRegex("if"          , 1);
-	private static final OORegex IN_KEYWORD_REGEX           = new UnitRegex("in"          , 1);
-	private static final OORegex INTERFACE_KEYWORD_REGEX    = new UnitRegex("interface"   , 1);
-	private static final OORegex IS_KEYWORD_REGEX           = new UnitRegex("is"          , 1);
+	private static final LexerRegex IF_KEYWORD_REGEX           = new UnitRegex("if"          , 1);
+	private static final LexerRegex IN_KEYWORD_REGEX           = new UnitRegex("in"          , 1);
+	private static final LexerRegex INTERFACE_KEYWORD_REGEX    = new UnitRegex("interface"   , 1);
+	private static final LexerRegex IS_KEYWORD_REGEX           = new UnitRegex("is"          , 1);
 	
-	private static final OORegex LIMITED_KEYWORD_REGEX      = new UnitRegex("limited"     , 1);
-	private static final OORegex LOOP_KEYWORD_REGEX         = new UnitRegex("loop"        , 1);
+	private static final LexerRegex LIMITED_KEYWORD_REGEX      = new UnitRegex("limited"     , 1);
+	private static final LexerRegex LOOP_KEYWORD_REGEX         = new UnitRegex("loop"        , 1);
 	
-	private static final OORegex MOD_KEYWORD_REGEX          = new UnitRegex("mod"         , 1);
+	private static final LexerRegex MOD_KEYWORD_REGEX          = new UnitRegex("mod"         , 1);
 	
-	private static final OORegex NEW_KEYWORD_REGEX          = new UnitRegex("new"         , 1);
-	private static final OORegex NOT_KEYWORD_REGEX          = new UnitRegex("not"         , 1);
-	private static final OORegex NULL_KEYWORD_REGEX         = new UnitRegex("null"        , 1);
+	private static final LexerRegex NEW_KEYWORD_REGEX          = new UnitRegex("new"         , 1);
+	private static final LexerRegex NOT_KEYWORD_REGEX          = new UnitRegex("not"         , 1);
+	private static final LexerRegex NULL_KEYWORD_REGEX         = new UnitRegex("null"        , 1);
 	
-	private static final OORegex OF_KEYWORD_REGEX           = new UnitRegex("of"          , 1);
-	private static final OORegex OR_KEYWORD_REGEX           = new UnitRegex("or"          , 1);
-	private static final OORegex OTHERS_KEYWORD_REGEX       = new UnitRegex("others"      , 1);
-	private static final OORegex OUT_KEYWORD_REGEX          = new UnitRegex("out"         , 1);
-	private static final OORegex OVERRIDING_KEYWORD_REGEX   = new UnitRegex("overriding"  , 1);
+	private static final LexerRegex OF_KEYWORD_REGEX           = new UnitRegex("of"          , 1);
+	private static final LexerRegex OR_KEYWORD_REGEX           = new UnitRegex("or"          , 1);
+	private static final LexerRegex OTHERS_KEYWORD_REGEX       = new UnitRegex("others"      , 1);
+	private static final LexerRegex OUT_KEYWORD_REGEX          = new UnitRegex("out"         , 1);
+	private static final LexerRegex OVERRIDING_KEYWORD_REGEX   = new UnitRegex("overriding"  , 1);
 	
-	private static final OORegex PACKAGE_KEYWORD_REGEX      = new UnitRegex("package"     , 1);
-	private static final OORegex PRAGMA_KEYWORD_REGEX       = new UnitRegex("pragma"      , 1);
-	private static final OORegex PRIVATE_KEYWORD_REGEX      = new UnitRegex("private"     , 1);
-	private static final OORegex PROCEDURE_KEYWORD_REGEX    = new UnitRegex("procedure"   , 1);
-	private static final OORegex PROTECTED_KEYWORD_REGEX    = new UnitRegex("protected"   , 1);
+	private static final LexerRegex PACKAGE_KEYWORD_REGEX      = new UnitRegex("package"     , 1);
+	private static final LexerRegex PRAGMA_KEYWORD_REGEX       = new UnitRegex("pragma"      , 1);
+	private static final LexerRegex PRIVATE_KEYWORD_REGEX      = new UnitRegex("private"     , 1);
+	private static final LexerRegex PROCEDURE_KEYWORD_REGEX    = new UnitRegex("procedure"   , 1);
+	private static final LexerRegex PROTECTED_KEYWORD_REGEX    = new UnitRegex("protected"   , 1);
 	
-	private static final OORegex RAISE_KEYWORD_REGEX        = new UnitRegex("raise"       , 1);
-	private static final OORegex RANGE_KEYWORD_REGEX        = new UnitRegex("range"       , 1);
-	private static final OORegex RECORD_KEYWORD_REGEX       = new UnitRegex("record"      , 1);
-	private static final OORegex REM_KEYWORD_REGEX          = new UnitRegex("rem"         , 1);
-	private static final OORegex RENAMES_KEYWORD_REGEX      = new UnitRegex("renames"     , 1);
-	private static final OORegex REQUEUE_KEYWORD_REGEX      = new UnitRegex("requeue"     , 1);
-	private static final OORegex RETURN_KEYWORD_REGEX       = new UnitRegex("return"      , 1);
-	private static final OORegex REVERSE_KEYWORD_REGEX      = new UnitRegex("reverse"     , 1);
+	private static final LexerRegex RAISE_KEYWORD_REGEX        = new UnitRegex("raise"       , 1);
+	private static final LexerRegex RANGE_KEYWORD_REGEX        = new UnitRegex("range"       , 1);
+	private static final LexerRegex RECORD_KEYWORD_REGEX       = new UnitRegex("record"      , 1);
+	private static final LexerRegex REM_KEYWORD_REGEX          = new UnitRegex("rem"         , 1);
+	private static final LexerRegex RENAMES_KEYWORD_REGEX      = new UnitRegex("renames"     , 1);
+	private static final LexerRegex REQUEUE_KEYWORD_REGEX      = new UnitRegex("requeue"     , 1);
+	private static final LexerRegex RETURN_KEYWORD_REGEX       = new UnitRegex("return"      , 1);
+	private static final LexerRegex REVERSE_KEYWORD_REGEX      = new UnitRegex("reverse"     , 1);
 	
-	private static final OORegex SELECT_KEYWORD_REGEX       = new UnitRegex("select"      , 1);
-	private static final OORegex SEPARATE_KEYWORD_REGEX     = new UnitRegex("separate"    , 1);
-	private static final OORegex SOME_KEYWORD_REGEX         = new UnitRegex("some"        , 1);
-	private static final OORegex SUBTYPE_KEYWORD_REGEX      = new UnitRegex("subtype"     , 1);
-	private static final OORegex SYNCHRONIZED_KEYWORD_REGEX = new UnitRegex("synchronized", 1);
+	private static final LexerRegex SELECT_KEYWORD_REGEX       = new UnitRegex("select"      , 1);
+	private static final LexerRegex SEPARATE_KEYWORD_REGEX     = new UnitRegex("separate"    , 1);
+	private static final LexerRegex SOME_KEYWORD_REGEX         = new UnitRegex("some"        , 1);
+	private static final LexerRegex SUBTYPE_KEYWORD_REGEX      = new UnitRegex("subtype"     , 1);
+	private static final LexerRegex SYNCHRONIZED_KEYWORD_REGEX = new UnitRegex("synchronized", 1);
 	
-	private static final OORegex TAGGED_KEYWORD_REGEX       = new UnitRegex("tagged"      , 1);
-	private static final OORegex TASK_KEYWORD_REGEX         = new UnitRegex("task"        , 1);
-	private static final OORegex TERMINATE_KEYWORD_REGEX    = new UnitRegex("terminate"   , 1);
-	private static final OORegex THEN_KEYWORD_REGEX         = new UnitRegex("then"        , 1);
-	private static final OORegex TYPE_KEYWORD_REGEX         = new UnitRegex("type"        , 1);
+	private static final LexerRegex TAGGED_KEYWORD_REGEX       = new UnitRegex("tagged"      , 1);
+	private static final LexerRegex TASK_KEYWORD_REGEX         = new UnitRegex("task"        , 1);
+	private static final LexerRegex TERMINATE_KEYWORD_REGEX    = new UnitRegex("terminate"   , 1);
+	private static final LexerRegex THEN_KEYWORD_REGEX         = new UnitRegex("then"        , 1);
+	private static final LexerRegex TYPE_KEYWORD_REGEX         = new UnitRegex("type"        , 1);
 	
-	private static final OORegex UNTIL_KEYWORD_REGEX        = new UnitRegex("until"       , 1);
-	private static final OORegex USE_KEYWORD_REGEX          = new UnitRegex("use"         , 1);
+	private static final LexerRegex UNTIL_KEYWORD_REGEX        = new UnitRegex("until"       , 1);
+	private static final LexerRegex USE_KEYWORD_REGEX          = new UnitRegex("use"         , 1);
 	
-	private static final OORegex WHEN_KEYWORD_REGEX         = new UnitRegex("when"        , 1);
-	private static final OORegex WHILE_KEYWORD_REGEX        = new UnitRegex("while"       , 1);
-	private static final OORegex WITH_KEYWORD_REGEX         = new UnitRegex("with"        , 1);
+	private static final LexerRegex WHEN_KEYWORD_REGEX         = new UnitRegex("when"        , 1);
+	private static final LexerRegex WHILE_KEYWORD_REGEX        = new UnitRegex("while"       , 1);
+	private static final LexerRegex WITH_KEYWORD_REGEX         = new UnitRegex("with"        , 1);
 	
-	private static final OORegex XOR_KEYWORD_REGEX          = new UnitRegex("xor"         , 1);
+	private static final LexerRegex XOR_KEYWORD_REGEX          = new UnitRegex("xor"         , 1);
 	
 	// Lexer data
 	
@@ -505,12 +505,12 @@ public final class AdaLexer extends LexerBase {
 	 * A map associating root regexes with the token types
 	 * they represent.
 	 */
-	private static final Map<OORegex, IElementType> REGEX_TOKEN_TYPES;
+	private static final Map<LexerRegex, IElementType> REGEX_TOKEN_TYPES;
 	
 	/**
 	 * The set of all root regexes (defined above).
 	 */
-	private static final Set<OORegex> ROOT_REGEXES;
+	private static final Set<LexerRegex> ROOT_REGEXES;
 	
 	/*
 		Static Initializer
@@ -704,7 +704,7 @@ public final class AdaLexer extends LexerBase {
 	/**
 	 * Constructs a new Ada Lexer.
 	 */
-	protected AdaLexer() {}
+	public AdaLexer() {}
 	
 	/*
 		Methods
@@ -801,12 +801,32 @@ public final class AdaLexer extends LexerBase {
 		
 		tokenStart = tokenEnd;
 		
-		Set<OORegex> regexes         = new HashSet<>(ROOT_REGEXES);
-		Set<OORegex> matchingRegexes = new HashSet<>();
+		// The offset by which the lexer needs to be rolled back before
+		// marking the end of the matched token. This happens for example
+		// when lexing the sequence "'Access" where:
+		// 1. After the "'" character, only the following regexes advance:
+		//    * APOSTROPHE_REGEX and it is nullable at this point
+		//    * CHARACTER_LITERAL_REGEX and it is not nullable at this point
+		// 2. After the "A" character, only the following regex advances:
+		//    * CHARACTER_LITERAL_REGEX and it is not nullable at this point
+		// 3. After the first "c" character, no regexes advance
+		// At this point, the matching regex is the nullable APOSTROPHE_REGEX
+		// obtained at step 1, so the lexer needs to "mark" the sequence "'"
+		// as the apostrophe token and roll back to the "A" character in
+		// order to start from there during the next call to `advance`
+		int rollBackOffset = 0;
+		
+		// The set of regexes that successfully advanced so far
+		Set<LexerRegex> regexes = new HashSet<>(ROOT_REGEXES);
+		
+		// The last set of regexes, resulting from an iteration of
+		// characterLoop, that contained at least one nullable regex
+		// (see rollBackOffset description for an example)
+		Set<LexerRegex> matchingRegexes = new HashSet<>();
 		
 		// A map specifying the root regex from which every regex originates
 		// by a series of calls to regex.advanced(char)
-		Map<OORegex, OORegex> regexLineages = new HashMap<>();
+		final Map<LexerRegex, LexerRegex> regexLineages = new HashMap<>();
 		
 		// The next character to be analysed
 		char nextCharacter = text.charAt(lexingOffset);
@@ -816,11 +836,11 @@ public final class AdaLexer extends LexerBase {
 		characterLoop: // label only used for reference in comments
 		while (tokenEnd == tokenStart) {
 			
-			final char CHARACTER = nextCharacter;
+			final char character = nextCharacter;
 			
-			// The set of regexes that advanced successfully in this
-			// iteration of characterLoop
-			Set<OORegex> advancedRegexes = new HashSet<>();
+			// The set of regexes that will have advanced successfully
+			// at the end of this iteration of characterLoop
+			final Set<LexerRegex> advancedRegexes = new HashSet<>();
 			
 			// For each regex that successfully advanced by all
 			// characters so far...
@@ -829,7 +849,7 @@ public final class AdaLexer extends LexerBase {
 				
 				// Try to advance the regex
 				
-				OORegex advancedRegex = regex.advanced(CHARACTER);
+				LexerRegex advancedRegex = regex.advanced(character);
 				
 				// If the regex advanced successfully, store it for the next
 				// iteration of characterLoop, and keep track of the root
@@ -839,7 +859,12 @@ public final class AdaLexer extends LexerBase {
 					
 					advancedRegexes.add(advancedRegex);
 					
-					OORegex ancestor = regexLineages.remove(regex);
+					LexerRegex ancestor = regexLineages.get(regex);
+					
+					if (advancedRegex.nullable() || !regex.nullable()) {
+						regexLineages.remove(regex);
+					}
+					
 					regexLineages.put(advancedRegex, ancestor == null ? regex : ancestor);
 					
 				}
@@ -857,11 +882,12 @@ public final class AdaLexer extends LexerBase {
 			
 			if (remainingRegexCount == 0 || lexingOffset == lexingEndOffset - 1) {
 				
-				Iterator<OORegex> matchingRegexIterator;
+				Iterator<LexerRegex> matchingRegexIterator;
 				
 				// If no remaining matching regexes exist, then choose a regex
-				// from those that matched during the previous iteration of
-				// characterLoop
+				// from those that last matched and had at least one nullable
+				// regex (or the empty set if either that was never the case, or
+				// this is the first iteration of characterLoop)
 				
 				if (remainingRegexCount == 0) {
 					matchingRegexIterator = matchingRegexes.iterator();
@@ -876,7 +902,7 @@ public final class AdaLexer extends LexerBase {
 					lexingOffset = lexingEndOffset;
 				}
 				
-				OORegex highestPriorityRegex = null;
+				LexerRegex highestPriorityRegex = null;
 				
 				// Find the matching regex with the highest priority
 				// The chosen regex still has to be nullable, which prevents for
@@ -889,7 +915,7 @@ public final class AdaLexer extends LexerBase {
 				
 				while (matchingRegexIterator.hasNext()) {
 					
-					OORegex regex = matchingRegexIterator.next();
+					LexerRegex regex = matchingRegexIterator.next();
 					
 					if (
 						regex.nullable() &&
@@ -910,7 +936,7 @@ public final class AdaLexer extends LexerBase {
 				
 				if (highestPriorityRegex != null) {
 					
-					OORegex rootRegex =
+					LexerRegex rootRegex =
 						regexLineages.getOrDefault(highestPriorityRegex, highestPriorityRegex);
 					
 					tokenType =
@@ -926,11 +952,19 @@ public final class AdaLexer extends LexerBase {
 					
 					// If this is a single-character, then the lexing offset
 					// needs to be advanced manually to avoid infinite calls
-					// to advance()
+					// to `advance`
 					
 					if (lexingOffset == tokenStart) { lexingOffset++; }
 					
+					// Reset the rollback offset
+					
+					rollBackOffset = 0;
+					
 				}
+				
+				// Roll the lexer back by the necessary offset
+				
+				lexingOffset -= rollBackOffset;
 				
 				// Set the token end offset to the lexing offset
 				// This will also break the execution of characterLoop
@@ -945,14 +979,29 @@ public final class AdaLexer extends LexerBase {
 			
 			else {
 				
+				// If at least one of the regexes that advanced successfully in
+				// this iteration of characterLoop is nullable, then store that
+				// set of regexes to be potentially used in the next iteration
+				// to find matching regexes, and reset the rollback offset
+				
+				if (regexes.stream().anyMatch(LexerRegex::nullable)) {
+					
+					matchingRegexes = new HashSet<>(regexes);
+					
+					rollBackOffset = 0;
+					
+				}
+				
+				// Otherwise, do not overwrite the last set of regexes with at
+				// least one nullable regex and increase the rollback offset
+				
+				else {
+					rollBackOffset++;
+				}
+				
 				// Advance the lexer to the next character
 				
 				nextCharacter = text.charAt(++lexingOffset);
-				
-				// Store the set of regexes that advanced successfully in this
-				// iteration of characterLoop (useful for the next iteration)
-				
-				matchingRegexes = new HashSet<>(regexes);
 				
 			}
 			
@@ -972,5 +1021,127 @@ public final class AdaLexer extends LexerBase {
 	 */
 	@Override
 	public int getBufferEnd() { return lexingEndOffset; }
+	
+	/*
+		Convenience Classes and Methods
+	*/
+	
+	/**
+	 * Simple data class representing a token.
+	 */
+	public static class Token {
+		
+		/**
+		 * The token's properties.
+		 */
+		public final IElementType TOKEN_TYPE;
+		public final int          START_OFFSET;
+		public final int          END_OFFSET;
+		
+		/**
+		 * Constructs a new token given a token type, start offset and
+		 * end offset.
+		 *
+		 * @param tokenType The token's type.
+		 * @param startOffset The token's start offset.
+		 * @param endOffset The token's end offset.
+		 */
+		public Token(IElementType tokenType, int startOffset, int endOffset) {
+			TOKEN_TYPE   = tokenType;
+			START_OFFSET = startOffset;
+			END_OFFSET   = endOffset;
+		}
+		
+		/**
+		 * Returns whether or not this token is equal to the given object.
+		 *
+		 * @param object The object to compare to this token.
+		 * @return The result of the comparison.
+		 */
+		@Override
+		public boolean equals(Object object) {
+			
+			if (!(object instanceof Token)) { return false; }
+			else {
+				
+				Token token = (Token)object;
+				
+				return token.TOKEN_TYPE.toString().equals(TOKEN_TYPE.toString()) &&
+					token.START_OFFSET == START_OFFSET && token.END_OFFSET == END_OFFSET;
+				
+			}
+			
+		}
+		
+		/**
+		 * Returns a string representation of this token.
+		 *
+		 * @return A string representation of this token.
+		 */
+		@Override
+		public String toString() {
+			return "Token(" + TOKEN_TYPE + ", " + START_OFFSET + ", " + END_OFFSET + ")";
+		}
+		
+	}
+	
+	/**
+	 * Performs lexical analysis over the given text by running a single
+	 * iteration of `advance` and returning the first token encountered.
+	 *
+	 * @param text The text over which to perform analysis.
+	 * @return The first token in the given text.
+	 */
+	@Nullable
+	public static Token firstToken(CharSequence text) {
+		
+		AdaLexer lexer = new AdaLexer();
+		
+		lexer.start(text, 0, text.length(), 0);
+		
+		return new Token(lexer.getTokenType(), lexer.getTokenStart(), lexer.getTokenEnd());
+		
+	}
+	
+	/**
+	 * Returns a token iterator that can be used to perform lazy lexical
+	 * analysis over the entire given text.
+	 *
+	 * @param text The text over which to perform analysis.
+	 * @return A lazy iterator over the tokens in the given text.
+	 */
+	public static Iterator<Token> textTokens(CharSequence text) {
+		
+		final AdaLexer lexer = new AdaLexer();
+		
+		lexer.start(text, 0, text.length(), 0);
+		
+		return new Iterator<Token>() {
+			
+			/**
+			 * @see java.util.Iterator#hasNext()
+			 */
+			@Override
+			public boolean hasNext() { return lexer.getTokenType() != null; }
+			
+			/**
+			 * @see java.util.Iterator#next()
+			 */
+			@Override
+			public Token next() {
+			
+				IElementType tokenType   = lexer.getTokenType();
+				int          startOffset = lexer.getTokenStart();
+				int          endOffset   = lexer.getTokenEnd();
+				
+				lexer.advance();
+				
+				return new Token(tokenType, startOffset, endOffset);
+			
+			}
+			
+		};
+		
+	}
 	
 }

--- a/src/main/control/com/adacore/adaintellij/lexanalysis/AdaSyntaxHighlighter.java
+++ b/src/main/control/com/adacore/adaintellij/lexanalysis/AdaSyntaxHighlighter.java
@@ -1,7 +1,5 @@
 package com.adacore.adaintellij.lexanalysis;
 
-import static com.intellij.openapi.editor.colors.TextAttributesKey.createTextAttributesKey;
-
 import com.intellij.lexer.Lexer;
 import com.intellij.openapi.editor.DefaultLanguageHighlighterColors;
 import com.intellij.openapi.editor.HighlighterColors;
@@ -9,6 +7,8 @@ import com.intellij.openapi.editor.colors.TextAttributesKey;
 import com.intellij.openapi.fileTypes.SyntaxHighlighterBase;
 import com.intellij.psi.tree.IElementType;
 import org.jetbrains.annotations.NotNull;
+
+import static com.intellij.openapi.editor.colors.TextAttributesKey.createTextAttributesKey;
 
 /**
  * Syntax highlighter for Ada 2012.
@@ -60,156 +60,34 @@ public final class AdaSyntaxHighlighter extends SyntaxHighlighterBase {
 	public TextAttributesKey[] getTokenHighlights(IElementType tokenType) {
 		
 		// Single-character and compound delimiters
-		if (
-			
-			tokenType == AdaTokenTypes.AMPERSAND           ||
-			tokenType == AdaTokenTypes.APOSTROPHE          ||
-			tokenType == AdaTokenTypes.LEFT_PARENTHESIS    ||
-			tokenType == AdaTokenTypes.RIGHT_PARENTHESIS   ||
-			tokenType == AdaTokenTypes.ASTERISK            ||
-			tokenType == AdaTokenTypes.PLUS_SIGN           ||
-			tokenType == AdaTokenTypes.COMMA               ||
-			tokenType == AdaTokenTypes.HYPHEN_MINUS        ||
-			tokenType == AdaTokenTypes.FULL_STOP           ||
-			tokenType == AdaTokenTypes.SOLIDUS             ||
-			tokenType == AdaTokenTypes.COLON               ||
-			tokenType == AdaTokenTypes.SEMICOLON           ||
-			tokenType == AdaTokenTypes.LESS_THAN_SIGN      ||
-			tokenType == AdaTokenTypes.EQUALS_SIGN         ||
-			tokenType == AdaTokenTypes.GREATER_THAN_SIGN   ||
-			tokenType == AdaTokenTypes.VERTICAL_LINE       ||
-			
-			tokenType == AdaTokenTypes.ARROW               ||
-			tokenType == AdaTokenTypes.DOUBLE_DOT          ||
-			tokenType == AdaTokenTypes.DOUBLE_ASTERISK     ||
-			tokenType == AdaTokenTypes.ASSIGNMENT          ||
-			tokenType == AdaTokenTypes.NOT_EQUAL_SIGN      ||
-			tokenType == AdaTokenTypes.GREATER_EQUAL_SIGN  ||
-			tokenType == AdaTokenTypes.LESS_EQUAL_SIGN     ||
-			tokenType == AdaTokenTypes.LEFT_LABEL_BRACKET  ||
-			tokenType == AdaTokenTypes.RIGHT_LABEL_BRACKET ||
-			tokenType == AdaTokenTypes.BOX_SIGN
-			
-		) { return DELIMITER_KEYS; }
+		if (AdaTokenTypes.DELIMITER_TOKEN_SET.contains(tokenType)) {
+			return DELIMITER_KEYS;
+		}
 		
 		// Identifiers
-		else if (tokenType == AdaTokenTypes.IDENTIFIER) { return IDENTIFIER_KEYS; }
+		else if (AdaTokenTypes.IDENTIFIER_TOKEN_SET.contains(tokenType)) {
+			return IDENTIFIER_KEYS;
+		}
 		
 		// Numeric literals
-		else if (
-			
-			tokenType == AdaTokenTypes.DECIMAL_LITERAL ||
-			tokenType == AdaTokenTypes.BASED_LITERAL
-			
-		) { return NUMERIC_LITERAL_KEYS; }
+		else if (AdaTokenTypes.NUMERIC_LITERAL_TOKEN_SET.contains(tokenType)) {
+			return NUMERIC_LITERAL_KEYS;
+		}
 		
 		// Textual literals
-		else if (
-			
-			tokenType == AdaTokenTypes.CHARACTER_LITERAL ||
-			tokenType == AdaTokenTypes.STRING_LITERAL
-			
-		) { return TEXTUAL_LITERAL_KEYS; }
+		else if (AdaTokenTypes.TEXTUAl_LITERAL_TOKEN_SET.contains(tokenType)) {
+			return TEXTUAL_LITERAL_KEYS;
+		}
 		
 		// Comments
-		else if (tokenType == AdaTokenTypes.COMMENT) { return COMMENT_KEYS; }
+		else if (AdaTokenTypes.COMMENT_TOKEN_SET.contains(tokenType)) {
+			return COMMENT_KEYS;
+		}
 		
 		// Keywords
-		else if (
-			
-			tokenType == AdaTokenTypes.ABORT_KEYWORD        ||
-			tokenType == AdaTokenTypes.ABS_KEYWORD          ||
-			tokenType == AdaTokenTypes.ABSTRACT_KEYWORD     ||
-			tokenType == AdaTokenTypes.ACCEPT_KEYWORD       ||
-			tokenType == AdaTokenTypes.ACCESS_KEYWORD       ||
-			tokenType == AdaTokenTypes.ALIASED_KEYWORD      ||
-			tokenType == AdaTokenTypes.ALL_KEYWORD          ||
-			tokenType == AdaTokenTypes.AND_KEYWORD          ||
-			tokenType == AdaTokenTypes.ARRAY_KEYWORD        ||
-			tokenType == AdaTokenTypes.AT_KEYWORD           ||
-			
-			tokenType == AdaTokenTypes.BEGIN_KEYWORD        ||
-			tokenType == AdaTokenTypes.BODY_KEYWORD         ||
-			
-			tokenType == AdaTokenTypes.CASE_KEYWORD         ||
-			tokenType == AdaTokenTypes.CONSTANT_KEYWORD     ||
-			
-			tokenType == AdaTokenTypes.DECLARE_KEYWORD      ||
-			tokenType == AdaTokenTypes.DELAY_KEYWORD        ||
-			tokenType == AdaTokenTypes.DELTA_KEYWORD        ||
-			tokenType == AdaTokenTypes.DIGITS_KEYWORD       ||
-			tokenType == AdaTokenTypes.DO_KEYWORD           ||
-			
-			tokenType == AdaTokenTypes.ELSE_KEYWORD         ||
-			tokenType == AdaTokenTypes.ELSIF_KEYWORD        ||
-			tokenType == AdaTokenTypes.END_KEYWORD          ||
-			tokenType == AdaTokenTypes.ENTRY_KEYWORD        ||
-			tokenType == AdaTokenTypes.EXCEPTION_KEYWORD    ||
-			tokenType == AdaTokenTypes.EXIT_KEYWORD         ||
-			
-			tokenType == AdaTokenTypes.FOR_KEYWORD          ||
-			tokenType == AdaTokenTypes.FUNCTION_KEYWORD     ||
-			
-			tokenType == AdaTokenTypes.GENERIC_KEYWORD      ||
-			tokenType == AdaTokenTypes.GOTO_KEYWORD         ||
-			
-			tokenType == AdaTokenTypes.IF_KEYWORD           ||
-			tokenType == AdaTokenTypes.IN_KEYWORD           ||
-			tokenType == AdaTokenTypes.INTERFACE_KEYWORD    ||
-			tokenType == AdaTokenTypes.IS_KEYWORD           ||
-			
-			tokenType == AdaTokenTypes.LIMITED_KEYWORD      ||
-			tokenType == AdaTokenTypes.LOOP_KEYWORD         ||
-			
-			tokenType == AdaTokenTypes.MOD_KEYWORD          ||
-			
-			tokenType == AdaTokenTypes.NEW_KEYWORD          ||
-			tokenType == AdaTokenTypes.NOT_KEYWORD          ||
-			tokenType == AdaTokenTypes.NULL_KEYWORD         ||
-			
-			tokenType == AdaTokenTypes.OF_KEYWORD           ||
-			tokenType == AdaTokenTypes.OR_KEYWORD           ||
-			tokenType == AdaTokenTypes.OTHERS_KEYWORD       ||
-			tokenType == AdaTokenTypes.OUT_KEYWORD          ||
-			tokenType == AdaTokenTypes.OVERRIDING_KEYWORD   ||
-			
-			tokenType == AdaTokenTypes.PACKAGE_KEYWORD      ||
-			tokenType == AdaTokenTypes.PRAGMA_KEYWORD       ||
-			tokenType == AdaTokenTypes.PRIVATE_KEYWORD      ||
-			tokenType == AdaTokenTypes.PROCEDURE_KEYWORD    ||
-			tokenType == AdaTokenTypes.PROTECTED_KEYWORD    ||
-			
-			tokenType == AdaTokenTypes.RAISE_KEYWORD        ||
-			tokenType == AdaTokenTypes.RANGE_KEYWORD        ||
-			tokenType == AdaTokenTypes.RECORD_KEYWORD       ||
-			tokenType == AdaTokenTypes.REM_KEYWORD          ||
-			tokenType == AdaTokenTypes.RENAMES_KEYWORD      ||
-			tokenType == AdaTokenTypes.REQUEUE_KEYWORD      ||
-			tokenType == AdaTokenTypes.RETURN_KEYWORD       ||
-			tokenType == AdaTokenTypes.REVERSE_KEYWORD      ||
-			
-			tokenType == AdaTokenTypes.SELECT_KEYWORD       ||
-			tokenType == AdaTokenTypes.SEPARATE_KEYWORD     ||
-			tokenType == AdaTokenTypes.SOME_KEYWORD         ||
-			tokenType == AdaTokenTypes.SUBTYPE_KEYWORD      ||
-			tokenType == AdaTokenTypes.SYNCHRONIZED_KEYWORD ||
-			
-			tokenType == AdaTokenTypes.TAGGED_KEYWORD       ||
-			tokenType == AdaTokenTypes.TASK_KEYWORD         ||
-			tokenType == AdaTokenTypes.TERMINATE_KEYWORD    ||
-			tokenType == AdaTokenTypes.THEN_KEYWORD         ||
-			tokenType == AdaTokenTypes.TYPE_KEYWORD         ||
-			
-			tokenType == AdaTokenTypes.UNTIL_KEYWORD        ||
-			tokenType == AdaTokenTypes.USE_KEYWORD          ||
-			
-			tokenType == AdaTokenTypes.WHEN_KEYWORD         ||
-			tokenType == AdaTokenTypes.WHILE_KEYWORD        ||
-			tokenType == AdaTokenTypes.WITH_KEYWORD         ||
-			
-			tokenType == AdaTokenTypes.XOR_KEYWORD
-			
-		) { return KEYWORD_KEYS; }
+		else if (AdaTokenTypes.KEYWORD_TOKEN_SET.contains(tokenType)) {
+			return KEYWORD_KEYS;
+		}
 		
 		// Invalid tokens
 		else if (tokenType == AdaTokenTypes.BAD_CHARACTER) { return BAD_CHARACTER_KEYS; }

--- a/src/main/control/com/adacore/adaintellij/lexanalysis/AdaTokenTypes.java
+++ b/src/main/control/com/adacore/adaintellij/lexanalysis/AdaTokenTypes.java
@@ -2,6 +2,7 @@ package com.adacore.adaintellij.lexanalysis;
 
 import com.intellij.psi.TokenType;
 import com.intellij.psi.tree.IElementType;
+import com.intellij.psi.tree.TokenSet;
 
 /**
  * Token types for Ada 2012.
@@ -16,154 +17,241 @@ public final class AdaTokenTypes {
 	/**
 	 * Ada token representing a contiguous whitespace sequence.
 	 */
-	public static final IElementType WHITESPACES          = TokenType.WHITE_SPACE;
+	static final IElementType WHITESPACES          = TokenType.WHITE_SPACE;
 	
 	/**
 	 * Ada token representing a syntactically invalid character.
 	 */
-	public static final IElementType BAD_CHARACTER        = TokenType.BAD_CHARACTER;
+	static final IElementType BAD_CHARACTER        = TokenType.BAD_CHARACTER;
 	
 	/**
 	 * Ada tokens representing single-character delimiters.
 	 */
-	public static final IElementType AMPERSAND            = new AdaTokenType("AMPERSAND");            // &
-	public static final IElementType APOSTROPHE           = new AdaTokenType("APOSTROPHE");           // '
-	public static final IElementType LEFT_PARENTHESIS     = new AdaTokenType("LEFT_PARENTHESIS");     // (
-	public static final IElementType RIGHT_PARENTHESIS    = new AdaTokenType("RIGHT_PARENTHESIS");    // )
-	public static final IElementType ASTERISK             = new AdaTokenType("ASTERISK");             // *
-	public static final IElementType PLUS_SIGN            = new AdaTokenType("PLUS_SIGN");            // +
-	public static final IElementType COMMA                = new AdaTokenType("COMMA");                // ,
-	public static final IElementType HYPHEN_MINUS         = new AdaTokenType("HYPHEN_MINUS");         // -
-	public static final IElementType FULL_STOP            = new AdaTokenType("FULL_STOP");            // .
-	public static final IElementType SOLIDUS              = new AdaTokenType("SOLIDUS");              // /
-	public static final IElementType COLON                = new AdaTokenType("COLON");                // :
-	public static final IElementType SEMICOLON            = new AdaTokenType("SEMICOLON");            // ;
-	public static final IElementType LESS_THAN_SIGN       = new AdaTokenType("LESS_THAN_SIGN");       // <
-	public static final IElementType EQUALS_SIGN          = new AdaTokenType("EQUALS_SIGN");          // =
-	public static final IElementType GREATER_THAN_SIGN    = new AdaTokenType("GREATER_THAN_SIGN");    // >
-	public static final IElementType VERTICAL_LINE        = new AdaTokenType("VERTICAL_LINE");        // |
+	static final IElementType AMPERSAND            = new AdaTokenType("AMPERSAND");            // &
+	static final IElementType APOSTROPHE           = new AdaTokenType("APOSTROPHE");           // '
+	static final IElementType LEFT_PARENTHESIS     = new AdaTokenType("LEFT_PARENTHESIS");     // (
+	static final IElementType RIGHT_PARENTHESIS    = new AdaTokenType("RIGHT_PARENTHESIS");    // )
+	static final IElementType ASTERISK             = new AdaTokenType("ASTERISK");             // *
+	static final IElementType PLUS_SIGN            = new AdaTokenType("PLUS_SIGN");            // +
+	static final IElementType COMMA                = new AdaTokenType("COMMA");                // ,
+	static final IElementType HYPHEN_MINUS         = new AdaTokenType("HYPHEN_MINUS");         // -
+	static final IElementType FULL_STOP            = new AdaTokenType("FULL_STOP");            // .
+	static final IElementType SOLIDUS              = new AdaTokenType("SOLIDUS");              // /
+	static final IElementType COLON                = new AdaTokenType("COLON");                // :
+	static final IElementType SEMICOLON            = new AdaTokenType("SEMICOLON");            // ;
+	static final IElementType LESS_THAN_SIGN       = new AdaTokenType("LESS_THAN_SIGN");       // <
+	static final IElementType EQUALS_SIGN          = new AdaTokenType("EQUALS_SIGN");          // =
+	static final IElementType GREATER_THAN_SIGN    = new AdaTokenType("GREATER_THAN_SIGN");    // >
+	static final IElementType VERTICAL_LINE        = new AdaTokenType("VERTICAL_LINE");        // |
 	
 	/**
 	 * Ada tokens representing compound delimiters.
 	 */
-	public static final IElementType ARROW                = new AdaTokenType("ARROW");                // =>
-	public static final IElementType DOUBLE_DOT           = new AdaTokenType("DOUBLE_DOT");           // ..
-	public static final IElementType DOUBLE_ASTERISK      = new AdaTokenType("DOUBLE_ASTERISK");      // **
-	public static final IElementType ASSIGNMENT           = new AdaTokenType("ASSIGNMENT");           // :=
-	public static final IElementType NOT_EQUAL_SIGN       = new AdaTokenType("NOT_EQUAL_SIGN");       // /=
-	public static final IElementType GREATER_EQUAL_SIGN   = new AdaTokenType("GREATER_EQUAL_SIGN");   // >=
-	public static final IElementType LESS_EQUAL_SIGN      = new AdaTokenType("LESS_EQUAL_SIGN");      // <=
-	public static final IElementType LEFT_LABEL_BRACKET   = new AdaTokenType("LEFT_LABEL_BRACKET");   // <<
-	public static final IElementType RIGHT_LABEL_BRACKET  = new AdaTokenType("RIGHT_LABEL_BRACKET");  // >>
-	public static final IElementType BOX_SIGN             = new AdaTokenType("BOX_SIGN");             // <>
+	static final IElementType ARROW                = new AdaTokenType("ARROW");                // =>
+	static final IElementType DOUBLE_DOT           = new AdaTokenType("DOUBLE_DOT");           // ..
+	static final IElementType DOUBLE_ASTERISK      = new AdaTokenType("DOUBLE_ASTERISK");      // **
+	static final IElementType ASSIGNMENT           = new AdaTokenType("ASSIGNMENT");           // :=
+	static final IElementType NOT_EQUAL_SIGN       = new AdaTokenType("NOT_EQUAL_SIGN");       // /=
+	static final IElementType GREATER_EQUAL_SIGN   = new AdaTokenType("GREATER_EQUAL_SIGN");   // >=
+	static final IElementType LESS_EQUAL_SIGN      = new AdaTokenType("LESS_EQUAL_SIGN");      // <=
+	static final IElementType LEFT_LABEL_BRACKET   = new AdaTokenType("LEFT_LABEL_BRACKET");   // <<
+	static final IElementType RIGHT_LABEL_BRACKET  = new AdaTokenType("RIGHT_LABEL_BRACKET");  // >>
+	static final IElementType BOX_SIGN             = new AdaTokenType("BOX_SIGN");             // <>
 	
 	/**
 	 * Ada tokens representing identifiers and literals.
 	 */
-	public static final IElementType IDENTIFIER           = new AdaTokenType("IDENTIFIER");           // ident3
-	public static final IElementType DECIMAL_LITERAL      = new AdaTokenType("DECIMAL_LITERAL");      // 3.14
-	public static final IElementType BASED_LITERAL        = new AdaTokenType("BASED_LITERAL");        // 16#F8#E1
-	public static final IElementType CHARACTER_LITERAL    = new AdaTokenType("CHARACTER_LITERAL");    // 'a'
-	public static final IElementType STRING_LITERAL       = new AdaTokenType("STRING_LITERAL");       // "hello :)"
+	static final IElementType IDENTIFIER           = new AdaTokenType("IDENTIFIER");           // ident3
+	static final IElementType DECIMAL_LITERAL      = new AdaTokenType("DECIMAL_LITERAL");      // 3.14
+	static final IElementType BASED_LITERAL        = new AdaTokenType("BASED_LITERAL");        // 16#F8#E1
+	static final IElementType CHARACTER_LITERAL    = new AdaTokenType("CHARACTER_LITERAL");    // 'a'
+	static final IElementType STRING_LITERAL       = new AdaTokenType("STRING_LITERAL");       // "hello :)"
 	
 	/**
 	 * Ada token representing a single comment.
 	 */
-	public static final IElementType COMMENT              = new AdaTokenType("COMMENT");              // -- Ada comment
+	static final IElementType COMMENT              = new AdaTokenType("COMMENT");              // -- Ada comment
 	
 	/**
 	 * Ada tokens representing reserved keywords.
 	 */
-	public static final IElementType ABORT_KEYWORD        = new AdaTokenType("ABORT_KEYWORD");        // abort
-	public static final IElementType ABS_KEYWORD          = new AdaTokenType("ABS_KEYWORD");          // abs
-	public static final IElementType ABSTRACT_KEYWORD     = new AdaTokenType("ABSTRACT_KEYWORD");     // abstract
-	public static final IElementType ACCEPT_KEYWORD       = new AdaTokenType("ACCEPT_KEYWORD");       // accept
-	public static final IElementType ACCESS_KEYWORD       = new AdaTokenType("ACCESS_KEYWORD");       // access
-	public static final IElementType ALIASED_KEYWORD      = new AdaTokenType("ALIASED_KEYWORD");      // aliased
-	public static final IElementType ALL_KEYWORD          = new AdaTokenType("ALL_KEYWORD");          // all
-	public static final IElementType AND_KEYWORD          = new AdaTokenType("AND_KEYWORD");          // and
-	public static final IElementType ARRAY_KEYWORD        = new AdaTokenType("ARRAY_KEYWORD");        // array
-	public static final IElementType AT_KEYWORD           = new AdaTokenType("AT_KEYWORD");           // at
+	static final IElementType ABORT_KEYWORD        = new AdaTokenType("ABORT_KEYWORD");        // abort
+	static final IElementType ABS_KEYWORD          = new AdaTokenType("ABS_KEYWORD");          // abs
+	static final IElementType ABSTRACT_KEYWORD     = new AdaTokenType("ABSTRACT_KEYWORD");     // abstract
+	static final IElementType ACCEPT_KEYWORD       = new AdaTokenType("ACCEPT_KEYWORD");       // accept
+	static final IElementType ACCESS_KEYWORD       = new AdaTokenType("ACCESS_KEYWORD");       // access
+	static final IElementType ALIASED_KEYWORD      = new AdaTokenType("ALIASED_KEYWORD");      // aliased
+	static final IElementType ALL_KEYWORD          = new AdaTokenType("ALL_KEYWORD");          // all
+	static final IElementType AND_KEYWORD          = new AdaTokenType("AND_KEYWORD");          // and
+	static final IElementType ARRAY_KEYWORD        = new AdaTokenType("ARRAY_KEYWORD");        // array
+	static final IElementType AT_KEYWORD           = new AdaTokenType("AT_KEYWORD");           // at
 	
-	public static final IElementType BEGIN_KEYWORD        = new AdaTokenType("BEGIN_KEYWORD");        // begin
-	public static final IElementType BODY_KEYWORD         = new AdaTokenType("BODY_KEYWORD");         // body
+	static final IElementType BEGIN_KEYWORD        = new AdaTokenType("BEGIN_KEYWORD");        // begin
+	static final IElementType BODY_KEYWORD         = new AdaTokenType("BODY_KEYWORD");         // body
 	
-	public static final IElementType CASE_KEYWORD         = new AdaTokenType("CASE_KEYWORD");         // case
-	public static final IElementType CONSTANT_KEYWORD     = new AdaTokenType("CONSTANT_KEYWORD");     // constant
+	static final IElementType CASE_KEYWORD         = new AdaTokenType("CASE_KEYWORD");         // case
+	static final IElementType CONSTANT_KEYWORD     = new AdaTokenType("CONSTANT_KEYWORD");     // constant
 	
-	public static final IElementType DECLARE_KEYWORD      = new AdaTokenType("DECLARE_KEYWORD");      // declare
-	public static final IElementType DELAY_KEYWORD        = new AdaTokenType("DELAY_KEYWORD");        // delay
-	public static final IElementType DELTA_KEYWORD        = new AdaTokenType("DELTA_KEYWORD");        // delta
-	public static final IElementType DIGITS_KEYWORD       = new AdaTokenType("DIGITS_KEYWORD");       // digits
-	public static final IElementType DO_KEYWORD           = new AdaTokenType("DO_KEYWORD");           // do
+	static final IElementType DECLARE_KEYWORD      = new AdaTokenType("DECLARE_KEYWORD");      // declare
+	static final IElementType DELAY_KEYWORD        = new AdaTokenType("DELAY_KEYWORD");        // delay
+	static final IElementType DELTA_KEYWORD        = new AdaTokenType("DELTA_KEYWORD");        // delta
+	static final IElementType DIGITS_KEYWORD       = new AdaTokenType("DIGITS_KEYWORD");       // digits
+	static final IElementType DO_KEYWORD           = new AdaTokenType("DO_KEYWORD");           // do
 	
-	public static final IElementType ELSE_KEYWORD         = new AdaTokenType("ELSE_KEYWORD");         // else
-	public static final IElementType ELSIF_KEYWORD        = new AdaTokenType("ELSIF_KEYWORD");        // elsif
-	public static final IElementType END_KEYWORD          = new AdaTokenType("END_KEYWORD");          // end
-	public static final IElementType ENTRY_KEYWORD        = new AdaTokenType("ENTRY_KEYWORD");        // entry
-	public static final IElementType EXCEPTION_KEYWORD    = new AdaTokenType("EXCEPTION_KEYWORD");    // exception
-	public static final IElementType EXIT_KEYWORD         = new AdaTokenType("EXIT_KEYWORD");         // exit
+	static final IElementType ELSE_KEYWORD         = new AdaTokenType("ELSE_KEYWORD");         // else
+	static final IElementType ELSIF_KEYWORD        = new AdaTokenType("ELSIF_KEYWORD");        // elsif
+	static final IElementType END_KEYWORD          = new AdaTokenType("END_KEYWORD");          // end
+	static final IElementType ENTRY_KEYWORD        = new AdaTokenType("ENTRY_KEYWORD");        // entry
+	static final IElementType EXCEPTION_KEYWORD    = new AdaTokenType("EXCEPTION_KEYWORD");    // exception
+	static final IElementType EXIT_KEYWORD         = new AdaTokenType("EXIT_KEYWORD");         // exit
 	
-	public static final IElementType FOR_KEYWORD          = new AdaTokenType("FOR_KEYWORD");          // for
-	public static final IElementType FUNCTION_KEYWORD     = new AdaTokenType("FUNCTION_KEYWORD");     // function
+	static final IElementType FOR_KEYWORD          = new AdaTokenType("FOR_KEYWORD");          // for
+	static final IElementType FUNCTION_KEYWORD     = new AdaTokenType("FUNCTION_KEYWORD");     // function
 	
-	public static final IElementType GENERIC_KEYWORD      = new AdaTokenType("GENERIC_KEYWORD");      // generic
-	public static final IElementType GOTO_KEYWORD         = new AdaTokenType("GOTO_KEYWORD");         // goto
+	static final IElementType GENERIC_KEYWORD      = new AdaTokenType("GENERIC_KEYWORD");      // generic
+	static final IElementType GOTO_KEYWORD         = new AdaTokenType("GOTO_KEYWORD");         // goto
 	
-	public static final IElementType IF_KEYWORD           = new AdaTokenType("IF_KEYWORD");           // if
-	public static final IElementType IN_KEYWORD           = new AdaTokenType("IN_KEYWORD");           // in
-	public static final IElementType INTERFACE_KEYWORD    = new AdaTokenType("INTERFACE_KEYWORD");    // interface
-	public static final IElementType IS_KEYWORD           = new AdaTokenType("IS_KEYWORD");           // is
+	static final IElementType IF_KEYWORD           = new AdaTokenType("IF_KEYWORD");           // if
+	static final IElementType IN_KEYWORD           = new AdaTokenType("IN_KEYWORD");           // in
+	static final IElementType INTERFACE_KEYWORD    = new AdaTokenType("INTERFACE_KEYWORD");    // interface
+	static final IElementType IS_KEYWORD           = new AdaTokenType("IS_KEYWORD");           // is
 	
-	public static final IElementType LIMITED_KEYWORD      = new AdaTokenType("LIMITED_KEYWORD");      // limited
-	public static final IElementType LOOP_KEYWORD         = new AdaTokenType("LOOP_KEYWORD");         // loop
+	static final IElementType LIMITED_KEYWORD      = new AdaTokenType("LIMITED_KEYWORD");      // limited
+	static final IElementType LOOP_KEYWORD         = new AdaTokenType("LOOP_KEYWORD");         // loop
 	
-	public static final IElementType MOD_KEYWORD          = new AdaTokenType("MOD_KEYWORD");          // mod
+	static final IElementType MOD_KEYWORD          = new AdaTokenType("MOD_KEYWORD");          // mod
 	
-	public static final IElementType NEW_KEYWORD          = new AdaTokenType("NEW_KEYWORD");          // new
-	public static final IElementType NOT_KEYWORD          = new AdaTokenType("NOT_KEYWORD");          // not
-	public static final IElementType NULL_KEYWORD         = new AdaTokenType("NULL_KEYWORD");         // null
+	static final IElementType NEW_KEYWORD          = new AdaTokenType("NEW_KEYWORD");          // new
+	static final IElementType NOT_KEYWORD          = new AdaTokenType("NOT_KEYWORD");          // not
+	static final IElementType NULL_KEYWORD         = new AdaTokenType("NULL_KEYWORD");         // null
 	
-	public static final IElementType OF_KEYWORD           = new AdaTokenType("OF_KEYWORD");           // of
-	public static final IElementType OR_KEYWORD           = new AdaTokenType("OR_KEYWORD");           // or
-	public static final IElementType OTHERS_KEYWORD       = new AdaTokenType("OTHERS_KEYWORD");       // others
-	public static final IElementType OUT_KEYWORD          = new AdaTokenType("OUT_KEYWORD");          // out
-	public static final IElementType OVERRIDING_KEYWORD   = new AdaTokenType("OVERRIDING_KEYWORD");   // overriding
+	static final IElementType OF_KEYWORD           = new AdaTokenType("OF_KEYWORD");           // of
+	static final IElementType OR_KEYWORD           = new AdaTokenType("OR_KEYWORD");           // or
+	static final IElementType OTHERS_KEYWORD       = new AdaTokenType("OTHERS_KEYWORD");       // others
+	static final IElementType OUT_KEYWORD          = new AdaTokenType("OUT_KEYWORD");          // out
+	static final IElementType OVERRIDING_KEYWORD   = new AdaTokenType("OVERRIDING_KEYWORD");   // overriding
 	
-	public static final IElementType PACKAGE_KEYWORD      = new AdaTokenType("PACKAGE_KEYWORD");      // package
-	public static final IElementType PRAGMA_KEYWORD       = new AdaTokenType("PRAGMA_KEYWORD");       // pragma
-	public static final IElementType PRIVATE_KEYWORD      = new AdaTokenType("PRIVATE_KEYWORD");      // private
-	public static final IElementType PROCEDURE_KEYWORD    = new AdaTokenType("PROCEDURE_KEYWORD");    // procedure
-	public static final IElementType PROTECTED_KEYWORD    = new AdaTokenType("PROTECTED_KEYWORD");    // protected
+	static final IElementType PACKAGE_KEYWORD      = new AdaTokenType("PACKAGE_KEYWORD");      // package
+	static final IElementType PRAGMA_KEYWORD       = new AdaTokenType("PRAGMA_KEYWORD");       // pragma
+	static final IElementType PRIVATE_KEYWORD      = new AdaTokenType("PRIVATE_KEYWORD");      // private
+	static final IElementType PROCEDURE_KEYWORD    = new AdaTokenType("PROCEDURE_KEYWORD");    // procedure
+	static final IElementType PROTECTED_KEYWORD    = new AdaTokenType("PROTECTED_KEYWORD");    // protected
 	
-	public static final IElementType RAISE_KEYWORD        = new AdaTokenType("RAISE_KEYWORD");        // raise
-	public static final IElementType RANGE_KEYWORD        = new AdaTokenType("RANGE_KEYWORD");        // range
-	public static final IElementType RECORD_KEYWORD       = new AdaTokenType("RECORD_KEYWORD");       // record
-	public static final IElementType REM_KEYWORD          = new AdaTokenType("REM_KEYWORD");          // rem
-	public static final IElementType RENAMES_KEYWORD      = new AdaTokenType("RENAMES_KEYWORD");      // renames
-	public static final IElementType REQUEUE_KEYWORD      = new AdaTokenType("REQUEUE_KEYWORD");      // requeue
-	public static final IElementType RETURN_KEYWORD       = new AdaTokenType("RETURN_KEYWORD");       // return
-	public static final IElementType REVERSE_KEYWORD      = new AdaTokenType("REVERSE_KEYWORD");      // reverse
+	static final IElementType RAISE_KEYWORD        = new AdaTokenType("RAISE_KEYWORD");        // raise
+	static final IElementType RANGE_KEYWORD        = new AdaTokenType("RANGE_KEYWORD");        // range
+	static final IElementType RECORD_KEYWORD       = new AdaTokenType("RECORD_KEYWORD");       // record
+	static final IElementType REM_KEYWORD          = new AdaTokenType("REM_KEYWORD");          // rem
+	static final IElementType RENAMES_KEYWORD      = new AdaTokenType("RENAMES_KEYWORD");      // renames
+	static final IElementType REQUEUE_KEYWORD      = new AdaTokenType("REQUEUE_KEYWORD");      // requeue
+	static final IElementType RETURN_KEYWORD       = new AdaTokenType("RETURN_KEYWORD");       // return
+	static final IElementType REVERSE_KEYWORD      = new AdaTokenType("REVERSE_KEYWORD");      // reverse
 	
-	public static final IElementType SELECT_KEYWORD       = new AdaTokenType("SELECT_KEYWORD");       // select
-	public static final IElementType SEPARATE_KEYWORD     = new AdaTokenType("SEPARATE_KEYWORD");     // separate
-	public static final IElementType SOME_KEYWORD         = new AdaTokenType("SOME_KEYWORD");         // some
-	public static final IElementType SUBTYPE_KEYWORD      = new AdaTokenType("SUBTYPE_KEYWORD");      // subtype
-	public static final IElementType SYNCHRONIZED_KEYWORD = new AdaTokenType("SYNCHRONIZED_KEYWORD"); // synchronized
+	static final IElementType SELECT_KEYWORD       = new AdaTokenType("SELECT_KEYWORD");       // select
+	static final IElementType SEPARATE_KEYWORD     = new AdaTokenType("SEPARATE_KEYWORD");     // separate
+	static final IElementType SOME_KEYWORD         = new AdaTokenType("SOME_KEYWORD");         // some
+	static final IElementType SUBTYPE_KEYWORD      = new AdaTokenType("SUBTYPE_KEYWORD");      // subtype
+	static final IElementType SYNCHRONIZED_KEYWORD = new AdaTokenType("SYNCHRONIZED_KEYWORD"); // synchronized
 	
-	public static final IElementType TAGGED_KEYWORD       = new AdaTokenType("TAGGED_KEYWORD");       // tagged
-	public static final IElementType TASK_KEYWORD         = new AdaTokenType("TASK_KEYWORD");         // task
-	public static final IElementType TERMINATE_KEYWORD    = new AdaTokenType("TERMINATE_KEYWORD");    // terminate
-	public static final IElementType THEN_KEYWORD         = new AdaTokenType("THEN_KEYWORD");         // then
-	public static final IElementType TYPE_KEYWORD         = new AdaTokenType("TYPE_KEYWORD");         // type
+	static final IElementType TAGGED_KEYWORD       = new AdaTokenType("TAGGED_KEYWORD");       // tagged
+	static final IElementType TASK_KEYWORD         = new AdaTokenType("TASK_KEYWORD");         // task
+	static final IElementType TERMINATE_KEYWORD    = new AdaTokenType("TERMINATE_KEYWORD");    // terminate
+	static final IElementType THEN_KEYWORD         = new AdaTokenType("THEN_KEYWORD");         // then
+	static final IElementType TYPE_KEYWORD         = new AdaTokenType("TYPE_KEYWORD");         // type
 	
-	public static final IElementType UNTIL_KEYWORD        = new AdaTokenType("UNTIL_KEYWORD");        // until
-	public static final IElementType USE_KEYWORD          = new AdaTokenType("USE_KEYWORD");          // use
+	static final IElementType UNTIL_KEYWORD        = new AdaTokenType("UNTIL_KEYWORD");        // until
+	static final IElementType USE_KEYWORD          = new AdaTokenType("USE_KEYWORD");          // use
 	
-	public static final IElementType WHEN_KEYWORD         = new AdaTokenType("WHEN_KEYWORD");         // when
-	public static final IElementType WHILE_KEYWORD        = new AdaTokenType("WHILE_KEYWORD");        // while
-	public static final IElementType WITH_KEYWORD         = new AdaTokenType("WITH_KEYWORD");         // with
+	static final IElementType WHEN_KEYWORD         = new AdaTokenType("WHEN_KEYWORD");         // when
+	static final IElementType WHILE_KEYWORD        = new AdaTokenType("WHILE_KEYWORD");        // while
+	static final IElementType WITH_KEYWORD         = new AdaTokenType("WITH_KEYWORD");         // with
 	
-	public static final IElementType XOR_KEYWORD          = new AdaTokenType("XOR_KEYWORD");          // xor
+	static final IElementType XOR_KEYWORD          = new AdaTokenType("XOR_KEYWORD");          // xor
+	
+	/**
+	 * Token set representing Ada whitespaces.
+	 */
+	public static final TokenSet WHITESPACE_TOKEN_SET = TokenSet.create(WHITESPACES);
+	
+	/**
+	 * Token set representing Ada delimiters.
+	 */
+	public static final TokenSet DELIMITER_TOKEN_SET = TokenSet.create(
+		
+		AMPERSAND, APOSTROPHE, LEFT_PARENTHESIS, RIGHT_PARENTHESIS, ASTERISK, PLUS_SIGN,
+		COMMA, HYPHEN_MINUS, FULL_STOP, SOLIDUS, COLON, SEMICOLON, LESS_THAN_SIGN,
+		EQUALS_SIGN, GREATER_THAN_SIGN, VERTICAL_LINE,
+		
+		ARROW, DOUBLE_DOT, DOUBLE_ASTERISK, ASSIGNMENT, NOT_EQUAL_SIGN, GREATER_EQUAL_SIGN,
+		LESS_EQUAL_SIGN, LEFT_LABEL_BRACKET, RIGHT_LABEL_BRACKET, BOX_SIGN
+		
+	);
+	
+	/**
+	 * Token sets representing Ada identifiers and literals.
+	 */
+	public static final TokenSet IDENTIFIER_TOKEN_SET      = TokenSet.create(IDENTIFIER);
+	public static final TokenSet STRING_LITERAL_TOKEN_SET  = TokenSet.create(STRING_LITERAL);
+	public static final TokenSet NUMERIC_LITERAL_TOKEN_SET = TokenSet.create(DECIMAL_LITERAL, BASED_LITERAL);
+	
+	public static final TokenSet TEXTUAl_LITERAL_TOKEN_SET = TokenSet.orSet(
+		TokenSet.create(CHARACTER_LITERAL), STRING_LITERAL_TOKEN_SET);
+	
+	public static final TokenSet LITERAL_TOKEN_SET         = TokenSet.orSet(
+		NUMERIC_LITERAL_TOKEN_SET, TEXTUAl_LITERAL_TOKEN_SET);
+	
+	/**
+	 * Token set representing Ada comments.
+	 */
+	public static final TokenSet COMMENT_TOKEN_SET = TokenSet.create(COMMENT);
+	
+	/**
+	 * Token set representing Ada reserved keywords.
+	 */
+	public static final TokenSet KEYWORD_TOKEN_SET = TokenSet.create(
+		
+		ABORT_KEYWORD, ABS_KEYWORD, ABSTRACT_KEYWORD, ACCEPT_KEYWORD, ACCESS_KEYWORD,
+		ALIASED_KEYWORD, ALL_KEYWORD, AND_KEYWORD, ARRAY_KEYWORD, AT_KEYWORD,
+		
+		BEGIN_KEYWORD, BODY_KEYWORD,
+		
+		CASE_KEYWORD, CONSTANT_KEYWORD,
+		
+		DECLARE_KEYWORD, DELAY_KEYWORD, DELTA_KEYWORD, DIGITS_KEYWORD, DO_KEYWORD,
+		
+		ELSE_KEYWORD, ELSIF_KEYWORD, END_KEYWORD, ENTRY_KEYWORD, EXCEPTION_KEYWORD,
+		EXIT_KEYWORD,
+		
+		FOR_KEYWORD, FUNCTION_KEYWORD,
+		
+		GENERIC_KEYWORD, GOTO_KEYWORD,
+		
+		IF_KEYWORD, IN_KEYWORD, INTERFACE_KEYWORD, IS_KEYWORD,
+		
+		LIMITED_KEYWORD, LOOP_KEYWORD,
+		
+		MOD_KEYWORD,
+		
+		NEW_KEYWORD, NOT_KEYWORD, NULL_KEYWORD,
+		
+		OF_KEYWORD, OR_KEYWORD, OTHERS_KEYWORD, OUT_KEYWORD, OVERRIDING_KEYWORD,
+		
+		PACKAGE_KEYWORD, PRAGMA_KEYWORD, PRIVATE_KEYWORD, PROCEDURE_KEYWORD,
+		PROTECTED_KEYWORD,
+		
+		RAISE_KEYWORD, RANGE_KEYWORD, RECORD_KEYWORD, REM_KEYWORD, RENAMES_KEYWORD,
+		REQUEUE_KEYWORD, RETURN_KEYWORD, REVERSE_KEYWORD,
+		
+		SELECT_KEYWORD, SEPARATE_KEYWORD, SOME_KEYWORD, SUBTYPE_KEYWORD,
+		SYNCHRONIZED_KEYWORD,
+		
+		TAGGED_KEYWORD, TASK_KEYWORD, TERMINATE_KEYWORD, THEN_KEYWORD, TYPE_KEYWORD,
+		
+		UNTIL_KEYWORD, USE_KEYWORD,
+		
+		WHEN_KEYWORD, WHILE_KEYWORD, WITH_KEYWORD,
+		
+		XOR_KEYWORD
+		
+	);
 	
 }

--- a/src/main/control/com/adacore/adaintellij/lexanalysis/regex/ConcatRegex.java
+++ b/src/main/control/com/adacore/adaintellij/lexanalysis/regex/ConcatRegex.java
@@ -142,7 +142,7 @@ public final class ConcatRegex implements OORegex {
 	@Override
 	public OORegex advanced(char character) {
 		
-		OORegex firstRegexAdvanced  = FIRST_REGEX.advanced(character);
+		OORegex firstRegexAdvanced = FIRST_REGEX.advanced(character);
 		
 		if (FIRST_REGEX.nullable()) {
 			
@@ -172,15 +172,9 @@ public final class ConcatRegex implements OORegex {
 			
 		} else {
 			
-			if (firstRegexAdvanced == null) {
-				
-				return null;
-				
-			} else {
-				
-				return new ConcatRegex(firstRegexAdvanced, SECOND_REGEX, PRIORITY);
-				
-			}
+			return firstRegexAdvanced == null ? null :
+				new ConcatRegex(firstRegexAdvanced, SECOND_REGEX, PRIORITY);
+			
 		}
 		
 	}

--- a/src/main/control/com/adacore/adaintellij/lexanalysis/regex/GeneralCategoryRegex.java
+++ b/src/main/control/com/adacore/adaintellij/lexanalysis/regex/GeneralCategoryRegex.java
@@ -10,18 +10,18 @@ import org.jetbrains.annotations.*;
  * Internally, a regex of this class stores a Java pattern compiled to
  * match only characters from a specific general category.
  */
-public final class GeneralCategoryRegex implements OORegex {
+public final class GeneralCategoryRegex implements LexerRegex {
 	
 	/**
 	 * The internal pattern used to match a character
 	 * based on its general category.
 	 */
-	public final Pattern PATTERN;
+	private final Pattern PATTERN;
 	
 	/**
 	 * The priority of this regex.
 	 */
-	public final int PRIORITY;
+	private final int PRIORITY;
 	
 	/**
 	 * Constructs a new general category regex given a general category
@@ -45,29 +45,29 @@ public final class GeneralCategoryRegex implements OORegex {
 	}
 	
 	/**
-	 * @see com.adacore.adaintellij.lexanalysis.regex.OORegex#nullable()
+	 * @see com.adacore.adaintellij.lexanalysis.regex.LexerRegex#nullable()
 	 */
 	@Override
 	public boolean nullable() { return false; }
 	
 	/**
-	 * @see com.adacore.adaintellij.lexanalysis.regex.OORegex#charactersMatched()
+	 * @see com.adacore.adaintellij.lexanalysis.regex.LexerRegex#charactersMatched()
 	 */
 	@Override
 	public int charactersMatched() { return 1; }
 	
 	/**
-	 * @see com.adacore.adaintellij.lexanalysis.regex.OORegex#getPriority()
+	 * @see com.adacore.adaintellij.lexanalysis.regex.LexerRegex#getPriority()
 	 */
 	@Override
 	public int getPriority() { return PRIORITY; }
 	
 	/**
-	 * @see com.adacore.adaintellij.lexanalysis.regex.OORegex#advanced(char)
+	 * @see com.adacore.adaintellij.lexanalysis.regex.LexerRegex#advanced(char)
 	 */
 	@Nullable
 	@Override
-	public OORegex advanced(char character) {
+	public LexerRegex advanced(char character) {
 		
 		return PATTERN.matcher(String.valueOf(character)).find() ?
 			new UnitRegex("") : null;

--- a/src/main/control/com/adacore/adaintellij/lexanalysis/regex/GeneralCategoryRegex.java
+++ b/src/main/control/com/adacore/adaintellij/lexanalysis/regex/GeneralCategoryRegex.java
@@ -40,8 +40,8 @@ public final class GeneralCategoryRegex implements OORegex {
 	 * @param priority The priority to assign to the constructed regex.
 	 */
 	public GeneralCategoryRegex(@NotNull String generalCategory, int priority) {
-		PATTERN          = Pattern.compile(String.format("\\p{%s}", generalCategory));
-		PRIORITY         = priority;
+		PATTERN  = Pattern.compile(String.format("\\p{%s}", generalCategory));
+		PRIORITY = priority;
 	}
 	
 	/**

--- a/src/main/control/com/adacore/adaintellij/lexanalysis/regex/IntersectionRegex.java
+++ b/src/main/control/com/adacore/adaintellij/lexanalysis/regex/IntersectionRegex.java
@@ -8,18 +8,18 @@ import org.jetbrains.annotations.*;
  * only if the two intersection subregexes can both advance by that
  * character.
  */
-public final class IntersectionRegex implements OORegex {
+public final class IntersectionRegex implements LexerRegex {
 	
 	/**
 	 * The intersection subregexes.
 	 */
-	public final OORegex FIRST_REGEX;
-	public final OORegex SECOND_REGEX;
+	final LexerRegex FIRST_REGEX;
+	final LexerRegex SECOND_REGEX;
 	
 	/**
 	 * The priority of this regex.
 	 */
-	public final int PRIORITY;
+	private final int PRIORITY;
 	
 	/**
 	 * Constructs a new intersection regex given two subregexes.
@@ -27,7 +27,7 @@ public final class IntersectionRegex implements OORegex {
 	 * @param firstRegex The first subregex.
 	 * @param secondRegex The second subregex.
 	 */
-	public IntersectionRegex(@NotNull OORegex firstRegex, @NotNull OORegex secondRegex) {
+	public IntersectionRegex(@NotNull LexerRegex firstRegex, @NotNull LexerRegex secondRegex) {
 		this(firstRegex, secondRegex, 0);
 	}
 	
@@ -39,20 +39,20 @@ public final class IntersectionRegex implements OORegex {
 	 * @param secondRegex The second subregex.
 	 * @param priority The priority to assign to the constructed regex.
 	 */
-	public IntersectionRegex(@NotNull OORegex firstRegex, @NotNull OORegex secondRegex, int priority) {
+	public IntersectionRegex(@NotNull LexerRegex firstRegex, @NotNull LexerRegex secondRegex, int priority) {
 		FIRST_REGEX  = firstRegex;
 		SECOND_REGEX = secondRegex;
 		PRIORITY     = priority;
 	}
 	
 	/**
-	 * @see com.adacore.adaintellij.lexanalysis.regex.OORegex#nullable()
+	 * @see com.adacore.adaintellij.lexanalysis.regex.LexerRegex#nullable()
 	 */
 	@Override
 	public boolean nullable() { return FIRST_REGEX.nullable() && SECOND_REGEX.nullable(); }
 	
 	/**
-	 * @see com.adacore.adaintellij.lexanalysis.regex.OORegex#charactersMatched()
+	 * @see com.adacore.adaintellij.lexanalysis.regex.LexerRegex#charactersMatched()
 	 */
 	@Override
 	public int charactersMatched() {
@@ -65,20 +65,20 @@ public final class IntersectionRegex implements OORegex {
 	}
 	
 	/**
-	 * @see com.adacore.adaintellij.lexanalysis.regex.OORegex#getPriority()
+	 * @see com.adacore.adaintellij.lexanalysis.regex.LexerRegex#getPriority()
 	 */
 	@Override
 	public int getPriority() { return PRIORITY; }
 	
 	/**
-	 * @see com.adacore.adaintellij.lexanalysis.regex.OORegex#advanced(char)
+	 * @see com.adacore.adaintellij.lexanalysis.regex.LexerRegex#advanced(char)
 	 */
 	@Nullable
 	@Override
-	public OORegex advanced(char character) {
+	public LexerRegex advanced(char character) {
 		
-		OORegex firstRegexAdvanced  = FIRST_REGEX.advanced(character);
-		OORegex secondRegexAdvanced = SECOND_REGEX.advanced(character);
+		LexerRegex firstRegexAdvanced  = FIRST_REGEX.advanced(character);
+		LexerRegex secondRegexAdvanced = SECOND_REGEX.advanced(character);
 		
 		return firstRegexAdvanced != null && secondRegexAdvanced != null ?
 			new IntersectionRegex(firstRegexAdvanced, secondRegexAdvanced, PRIORITY) : null;

--- a/src/main/control/com/adacore/adaintellij/lexanalysis/regex/LexerRegex.java
+++ b/src/main/control/com/adacore/adaintellij/lexanalysis/regex/LexerRegex.java
@@ -6,19 +6,19 @@ import org.jetbrains.annotations.*;
  * Object-Based Regular Expression specifically designed
  * to be used by a Lexical Analyser.
  * The main feature of this lexer-targeting regex interface
- * is the advanced method which allows matching a sequence of
+ * is the `advanced` method which allows matching a sequence of
  * characters incrementally, filtering out non matching regexes
  * along the way.
  * Any implementing class must be immutable by design. This
  * allows regexes to be reused when defining complex regexes.
  */
-public interface OORegex {
+public interface LexerRegex {
 	
 	/**
 	 * Returns whether or not this regex is nullable, i.e. whether
 	 * or not it accepts the empty string.
 	 * Not to be confused with the possibility of a variable being null,
-	 * as can be indicated with JetBrains' @NotNull annotation.
+	 * as can be indicated with JetBrains' @Nullable annotation.
 	 *
 	 * @return The "nullability" of this regex.
 	 */
@@ -68,6 +68,6 @@ public interface OORegex {
 	 * @return The advanced regex.
 	 */
 	@Nullable
-	OORegex advanced(char character);
+	LexerRegex advanced(char character);
 	
 }

--- a/src/main/control/com/adacore/adaintellij/lexanalysis/regex/NotRegex.java
+++ b/src/main/control/com/adacore/adaintellij/lexanalysis/regex/NotRegex.java
@@ -6,28 +6,28 @@ import org.jetbrains.annotations.*;
  * Regex matching a single character not matched by another
  * single-character subregex.
  * To avoid overly complex inheritance hierarchy, the NotRegex
- * constructor simply uses the charactersMatched() method to
+ * constructor simply uses the `charactersMatched` method to
  * check that the regex it receives matches a single character,
  * and throws an exception otherwise.
  */
-public final class NotRegex implements OORegex {
+public final class NotRegex implements LexerRegex {
 	
 	/**
 	 * The negated subregex.
 	 */
-	public final OORegex REGEX;
+	final LexerRegex REGEX;
 	
 	/**
 	 * The priority of this regex.
 	 */
-	public final int PRIORITY;
+	private final int PRIORITY;
 	
 	/**
 	 * Constructs a new not regex given a subregex.
 	 *
 	 * @param regex The negated subregex.
 	 */
-	public NotRegex(@NotNull OORegex regex) { this(regex, 0); }
+	public NotRegex(@NotNull LexerRegex regex) { this(regex, 0); }
 	
 	/**
 	 * Constructs a new not regex given a subregex and a priority.
@@ -37,7 +37,7 @@ public final class NotRegex implements OORegex {
 	 * @throws IllegalArgumentException If the received regex does not
 	 *                                  match a single character.
 	 */
-	public NotRegex(@NotNull OORegex regex, int priority) {
+	public NotRegex(@NotNull LexerRegex regex, int priority) {
 		
 		int regexCharacters = regex.charactersMatched();
 		
@@ -53,31 +53,31 @@ public final class NotRegex implements OORegex {
 	}
 	
 	/**
-	 * @see com.adacore.adaintellij.lexanalysis.regex.OORegex#nullable()
+	 * @see com.adacore.adaintellij.lexanalysis.regex.LexerRegex#nullable()
 	 */
 	@Override
 	public boolean nullable() { return false; }
 	
 	/**
-	 * @see com.adacore.adaintellij.lexanalysis.regex.OORegex#charactersMatched()
+	 * @see com.adacore.adaintellij.lexanalysis.regex.LexerRegex#charactersMatched()
 	 */
 	@Override
 	public int charactersMatched() { return 1; }
 	
 	/**
-	 * @see com.adacore.adaintellij.lexanalysis.regex.OORegex#getPriority()
+	 * @see com.adacore.adaintellij.lexanalysis.regex.LexerRegex#getPriority()
 	 */
 	@Override
 	public int getPriority() { return PRIORITY; }
 	
 	/**
-	 * @see com.adacore.adaintellij.lexanalysis.regex.OORegex#advanced(char)
+	 * @see com.adacore.adaintellij.lexanalysis.regex.LexerRegex#advanced(char)
 	 */
 	@Nullable
 	@Override
-	public OORegex advanced(char character) {
+	public LexerRegex advanced(char character) {
 		
-		OORegex advancedRegex = REGEX.advanced(character);
+		LexerRegex advancedRegex = REGEX.advanced(character);
 		
 		return advancedRegex == null ?
 			new UnitRegex("", PRIORITY) : null;

--- a/src/main/control/com/adacore/adaintellij/lexanalysis/regex/OneOrMoreRegex.java
+++ b/src/main/control/com/adacore/adaintellij/lexanalysis/regex/OneOrMoreRegex.java
@@ -6,24 +6,24 @@ import org.jetbrains.annotations.*;
  * Regex matching one or more occurrences of a sequence
  * of characters matched by a subregex.
  */
-public final class OneOrMoreRegex implements OORegex {
+public final class OneOrMoreRegex implements LexerRegex {
 	
 	/**
 	 * The subregex to be matched one or more times.
 	 */
-	public final OORegex REGEX;
+	final LexerRegex REGEX;
 	
 	/**
 	 * The priority of this regex.
 	 */
-	public final int PRIORITY;
+	private final int PRIORITY;
 	
 	/**
 	 * Constructs a new one or more regex given a subregex.
 	 *
 	 * @param regex The subregex for the one or more regex.
 	 */
-	public OneOrMoreRegex(@NotNull OORegex regex) { this(regex, 0); }
+	public OneOrMoreRegex(@NotNull LexerRegex regex) { this(regex, 0); }
 	
 	/**
 	 * Constructs a new one or more regex given a subregex and
@@ -32,40 +32,40 @@ public final class OneOrMoreRegex implements OORegex {
 	 * @param regex The subregex for the one or more regex.
 	 * @param priority The priority to assign to the constructed regex.
 	 */
-	public OneOrMoreRegex(@NotNull OORegex regex, int priority) {
+	public OneOrMoreRegex(@NotNull LexerRegex regex, int priority) {
 		REGEX    = regex;
 		PRIORITY = priority;
 	}
 	
 	/**
-	 * @see com.adacore.adaintellij.lexanalysis.regex.OORegex#nullable()
+	 * @see com.adacore.adaintellij.lexanalysis.regex.LexerRegex#nullable()
 	 */
 	@Override
 	public boolean nullable() { return REGEX.nullable(); }
 	
 	/**
-	 * @see com.adacore.adaintellij.lexanalysis.regex.OORegex#charactersMatched()
+	 * @see com.adacore.adaintellij.lexanalysis.regex.LexerRegex#charactersMatched()
 	 */
 	@Override
 	public int charactersMatched() { return -1; }
 	
 	/**
-	 * @see com.adacore.adaintellij.lexanalysis.regex.OORegex#getPriority()
+	 * @see com.adacore.adaintellij.lexanalysis.regex.LexerRegex#getPriority()
 	 */
 	@Override
 	public int getPriority() { return PRIORITY; }
 	
 	/**
-	 * @see com.adacore.adaintellij.lexanalysis.regex.OORegex#advanced(char)
+	 * @see com.adacore.adaintellij.lexanalysis.regex.LexerRegex#advanced(char)
 	 */
 	@Nullable
 	@Override
-	public OORegex advanced(char character) {
+	public LexerRegex advanced(char character) {
 		
-		OORegex advancedRegex = REGEX.advanced(character);
+		LexerRegex advancedRegex = REGEX.advanced(character);
 		
 		return advancedRegex == null ? null :
-			new ConcatRegex(
+			new ConcatenationRegex(
 				advancedRegex,
 				new ZeroOrMoreRegex(REGEX, PRIORITY),
 				PRIORITY

--- a/src/main/control/com/adacore/adaintellij/lexanalysis/regex/UnionRegex.java
+++ b/src/main/control/com/adacore/adaintellij/lexanalysis/regex/UnionRegex.java
@@ -7,18 +7,18 @@ import org.jetbrains.annotations.*;
 /**
  * Regex matching the union of two subregexes.
  */
-public final class UnionRegex implements OORegex {
+public final class UnionRegex implements LexerRegex {
 	
 	/**
 	 * The union subregexes.
 	 */
-	public final OORegex FIRST_REGEX;
-	public final OORegex SECOND_REGEX;
+	final LexerRegex FIRST_REGEX;
+	final LexerRegex SECOND_REGEX;
 	
 	/**
 	 * The priority of this regex.
 	 */
-	public final int PRIORITY;
+	private final int PRIORITY;
 	
 	/**
 	 * Constructs a new union regex given two subregexes.
@@ -26,7 +26,7 @@ public final class UnionRegex implements OORegex {
 	 * @param firstRegex The first subregex.
 	 * @param secondRegex The second subregex.
 	 */
-	public UnionRegex(@NotNull OORegex firstRegex, @NotNull OORegex secondRegex) {
+	public UnionRegex(@NotNull LexerRegex firstRegex, @NotNull LexerRegex secondRegex) {
 		this(firstRegex, secondRegex, 0);
 	}
 	
@@ -38,7 +38,7 @@ public final class UnionRegex implements OORegex {
 	 * @param secondRegex The second subregex.
 	 * @param priority The priority to assign to the constructed regex.
 	 */
-	public UnionRegex(@NotNull OORegex firstRegex, @NotNull OORegex secondRegex, int priority) {
+	public UnionRegex(@NotNull LexerRegex firstRegex, @NotNull LexerRegex secondRegex, int priority) {
 		FIRST_REGEX  = firstRegex;
 		SECOND_REGEX = secondRegex;
 		PRIORITY     = priority;
@@ -67,21 +67,21 @@ public final class UnionRegex implements OORegex {
 	 * @param regexes The list of regexes to unite.
 	 * @return A hierarchy of union regexes.
 	 */
-	public static OORegex fromList(@NotNull final List<OORegex> regexes) {
+	public static LexerRegex fromList(@NotNull final List<LexerRegex> regexes) {
 		
 		int regexesSize = regexes.size();
 		
 		if (regexesSize == 0) { return null; }
 		
-		ListIterator<OORegex> regexIterator = regexes.listIterator(regexesSize);
+		ListIterator<LexerRegex> regexIterator = regexes.listIterator(regexesSize);
 		
-		OORegex regex = regexIterator.previous();
+		LexerRegex regex = regexIterator.previous();
 		
 		int maxPriority = regex.getPriority();
 		
 		while (regexIterator.hasPrevious()) {
 			
-			OORegex nextRegex = regexIterator.previous();
+			LexerRegex nextRegex = regexIterator.previous();
 			
 			int nextRegexPriority = nextRegex.getPriority();
 			
@@ -99,12 +99,12 @@ public final class UnionRegex implements OORegex {
 	
 	/**
 	 * Returns a new hierarchy of union regexes from an arbitrary
-	 * number of regexes (Java varargs) using fromList(List<OORegex>).
+	 * number of regexes (Java varargs) using fromList(List<LexerRegex>).
 	 *
 	 * @param regexes The regexes to unite.
 	 * @return A hierarchy of union regexes.
 	 */
-	public static OORegex fromRegexes(@NotNull OORegex... regexes) {
+	public static LexerRegex fromRegexes(@NotNull LexerRegex... regexes) {
 		return fromList(Arrays.asList(regexes));
 	}
 	
@@ -117,7 +117,7 @@ public final class UnionRegex implements OORegex {
 	 * @param toChar The upper bound character of the range.
 	 * @return A hierarchy of union regexes matching a range of characters.
 	 */
-	public static OORegex fromRange(char fromChar, char toChar) {
+	public static LexerRegex fromRange(char fromChar, char toChar) {
 		return fromRange(fromChar, toChar, 0);
 	}
 	
@@ -134,14 +134,15 @@ public final class UnionRegex implements OORegex {
 	 * @return A hierarchy of union regexes matching a range of characters.
 	 * @throws IllegalArgumentException If fromChar is greater than toChar.
 	 */
-	public static OORegex fromRange(char fromChar, char toChar, int priority) {
+	public static LexerRegex fromRange(char fromChar, char toChar, int priority) {
 		
 		if (fromChar > toChar) {
 			throw new IllegalArgumentException("Invalid bounds: fromChar must be smaller or equal to toChar");
 		}
 		
 		char character = toChar;
-		OORegex regex  = new UnitRegex(Character.toString(character), priority);
+		
+		LexerRegex regex = new UnitRegex(Character.toString(character), priority);
 		
 		while (character != fromChar) {
 			regex = new UnionRegex(
@@ -156,13 +157,13 @@ public final class UnionRegex implements OORegex {
 	}
 	
 	/**
-	 * @see com.adacore.adaintellij.lexanalysis.regex.OORegex#nullable()
+	 * @see com.adacore.adaintellij.lexanalysis.regex.LexerRegex#nullable()
 	 */
 	@Override
 	public boolean nullable() { return FIRST_REGEX.nullable() || SECOND_REGEX.nullable(); }
 	
 	/**
-	 * @see com.adacore.adaintellij.lexanalysis.regex.OORegex#charactersMatched()
+	 * @see com.adacore.adaintellij.lexanalysis.regex.LexerRegex#charactersMatched()
 	 */
 	@Override
 	public int charactersMatched() {
@@ -175,20 +176,20 @@ public final class UnionRegex implements OORegex {
 	}
 	
 	/**
-	 * @see com.adacore.adaintellij.lexanalysis.regex.OORegex#getPriority()
+	 * @see com.adacore.adaintellij.lexanalysis.regex.LexerRegex#getPriority()
 	 */
 	@Override
 	public int getPriority() { return PRIORITY; }
 	
 	/**
-	 * @see com.adacore.adaintellij.lexanalysis.regex.OORegex#advanced(char)
+	 * @see com.adacore.adaintellij.lexanalysis.regex.LexerRegex#advanced(char)
 	 */
 	@Nullable
 	@Override
-	public OORegex advanced(char character) {
+	public LexerRegex advanced(char character) {
 		
-		OORegex firstRegexAdvanced  = FIRST_REGEX.advanced(character);
-		OORegex secondRegexAdvanced = SECOND_REGEX.advanced(character);
+		LexerRegex firstRegexAdvanced  = FIRST_REGEX.advanced(character);
+		LexerRegex secondRegexAdvanced = SECOND_REGEX.advanced(character);
 		
 		if (firstRegexAdvanced == null && secondRegexAdvanced == null) {
 			

--- a/src/main/control/com/adacore/adaintellij/lexanalysis/regex/UnionRegex.java
+++ b/src/main/control/com/adacore/adaintellij/lexanalysis/regex/UnionRegex.java
@@ -138,12 +138,10 @@ public final class UnionRegex implements OORegex {
 		
 		if (fromChar > toChar) {
 			throw new IllegalArgumentException("Invalid bounds: fromChar must be smaller or equal to toChar");
-		} else if (fromChar == toChar) {
-			return new UnitRegex(Character.toString(fromChar), priority);
 		}
 		
 		char character = toChar;
-		OORegex regex  = new UnitRegex(Character.toString(toChar), priority);
+		OORegex regex  = new UnitRegex(Character.toString(character), priority);
 		
 		while (character != fromChar) {
 			regex = new UnionRegex(

--- a/src/main/control/com/adacore/adaintellij/lexanalysis/regex/UnitRegex.java
+++ b/src/main/control/com/adacore/adaintellij/lexanalysis/regex/UnitRegex.java
@@ -7,17 +7,17 @@ import org.jetbrains.annotations.*;
  * unlike other types of regexes that are defined recursively
  * using other regexes.
  */
-public final class UnitRegex implements OORegex {
+public final class UnitRegex implements LexerRegex {
 	
 	/**
 	 * The sequence of characters matched by this regex.
 	 */
-	public final String SEQUENCE;
+	final String SEQUENCE;
 	
 	/**
 	 * The priority of this regex.
 	 */
-	public final int PRIORITY;
+	private final int PRIORITY;
 	
 	/**
 	 * Constructs a new unit regex given a sequence of characters.
@@ -39,29 +39,29 @@ public final class UnitRegex implements OORegex {
 	}
 	
 	/**
-	 * @see com.adacore.adaintellij.lexanalysis.regex.OORegex#nullable()
+	 * @see com.adacore.adaintellij.lexanalysis.regex.LexerRegex#nullable()
 	 */
 	@Override
 	public boolean nullable() { return SEQUENCE.length() == 0; }
 	
 	/**
-	 * @see com.adacore.adaintellij.lexanalysis.regex.OORegex#charactersMatched()
+	 * @see com.adacore.adaintellij.lexanalysis.regex.LexerRegex#charactersMatched()
 	 */
 	@Override
 	public int charactersMatched() { return SEQUENCE.length(); }
 	
 	/**
-	 * @see com.adacore.adaintellij.lexanalysis.regex.OORegex#getPriority()
+	 * @see com.adacore.adaintellij.lexanalysis.regex.LexerRegex#getPriority()
 	 */
 	@Override
 	public int getPriority() { return PRIORITY; }
 	
 	/**
-	 * @see com.adacore.adaintellij.lexanalysis.regex.OORegex#advanced(char)
+	 * @see com.adacore.adaintellij.lexanalysis.regex.LexerRegex#advanced(char)
 	 */
 	@Nullable
 	@Override
-	public OORegex advanced(char character) {
+	public LexerRegex advanced(char character) {
 		return SEQUENCE.length() == 0 || SEQUENCE.charAt(0) != character ?
 			null : new UnitRegex(SEQUENCE.substring(1), PRIORITY);
 	}

--- a/src/main/control/com/adacore/adaintellij/lexanalysis/regex/ZeroOrMoreRegex.java
+++ b/src/main/control/com/adacore/adaintellij/lexanalysis/regex/ZeroOrMoreRegex.java
@@ -6,24 +6,24 @@ import org.jetbrains.annotations.*;
  * Regex matching zero or more occurrences of a sequence
  * of characters matched by a subregex.
  */
-public final class ZeroOrMoreRegex implements OORegex {
+public final class ZeroOrMoreRegex implements LexerRegex {
 	
 	/**
 	 * The subregex to be matched zero or more times.
 	 */
-	public final OORegex REGEX;
+	final LexerRegex REGEX;
 	
 	/**
 	 * The priority of this regex.
 	 */
-	public final int PRIORITY;
+	private final int PRIORITY;
 	
 	/**
 	 * Constructs a new zero or more regex given a subregex.
 	 *
 	 * @param regex The subregex for the zero or more regex.
 	 */
-	public ZeroOrMoreRegex(@NotNull OORegex regex) { this(regex, 0); }
+	public ZeroOrMoreRegex(@NotNull LexerRegex regex) { this(regex, 0); }
 	
 	/**
 	 * Constructs a new zero or more regex given a subregex and
@@ -32,40 +32,40 @@ public final class ZeroOrMoreRegex implements OORegex {
 	 * @param regex The subregex for the zero or more regex.
 	 * @param priority The priority to assign to the constructed regex.
 	 */
-	public ZeroOrMoreRegex(@NotNull OORegex regex, int priority) {
+	public ZeroOrMoreRegex(@NotNull LexerRegex regex, int priority) {
 		REGEX    = regex;
 		PRIORITY = priority;
 	}
 	
 	/**
-	 * @see com.adacore.adaintellij.lexanalysis.regex.OORegex#nullable()
+	 * @see com.adacore.adaintellij.lexanalysis.regex.LexerRegex#nullable()
 	 */
 	@Override
 	public boolean nullable() { return true; }
 	
 	/**
-	 * @see com.adacore.adaintellij.lexanalysis.regex.OORegex#charactersMatched()
+	 * @see com.adacore.adaintellij.lexanalysis.regex.LexerRegex#charactersMatched()
 	 */
 	@Override
 	public int charactersMatched() { return -1; }
 	
 	/**
-	 * @see com.adacore.adaintellij.lexanalysis.regex.OORegex#getPriority()
+	 * @see com.adacore.adaintellij.lexanalysis.regex.LexerRegex#getPriority()
 	 */
 	@Override
 	public int getPriority() { return PRIORITY; }
 	
 	/**
-	 * @see com.adacore.adaintellij.lexanalysis.regex.OORegex#advanced(char)
+	 * @see com.adacore.adaintellij.lexanalysis.regex.LexerRegex#advanced(char)
 	 */
 	@Nullable
 	@Override
-	public OORegex advanced(char character) {
+	public LexerRegex advanced(char character) {
 		
-		OORegex advancedRegex = REGEX.advanced(character);
+		LexerRegex advancedRegex = REGEX.advanced(character);
 		
 		return advancedRegex == null ? null :
-			new ConcatRegex(advancedRegex, this, PRIORITY);
+			new ConcatenationRegex(advancedRegex, this, PRIORITY);
 		
 	}
 	

--- a/src/main/control/com/adacore/adaintellij/lexanalysis/regex/ZeroOrOneRegex.java
+++ b/src/main/control/com/adacore/adaintellij/lexanalysis/regex/ZeroOrOneRegex.java
@@ -6,24 +6,24 @@ import org.jetbrains.annotations.*;
  * Regex matching zero or one occurrences of a sequence
  * of characters matched by a subregex.
  */
-public final class ZeroOrOneRegex implements OORegex {
+public final class ZeroOrOneRegex implements LexerRegex {
 	
 	/**
 	 * The subregex to be matched zero or one times.
 	 */
-	public final OORegex REGEX;
+	final LexerRegex REGEX;
 	
 	/**
 	 * The priority of this regex.
 	 */
-	public final int PRIORITY;
+	private final int PRIORITY;
 	
 	/**
 	 * Constructs a new zero or one regex given a subregex.
 	 *
 	 * @param regex The subregex for the zero or one regex.
 	 */
-	public ZeroOrOneRegex(@NotNull OORegex regex) { this(regex, 0); }
+	public ZeroOrOneRegex(@NotNull LexerRegex regex) { this(regex, 0); }
 	
 	/**
 	 * Constructs a new zero or one regex given a subregex and
@@ -32,34 +32,34 @@ public final class ZeroOrOneRegex implements OORegex {
 	 * @param regex The subregex for the zero or one regex.
 	 * @param priority The priority to assign to the constructed regex.
 	 */
-	public ZeroOrOneRegex(@NotNull OORegex regex, int priority) {
+	public ZeroOrOneRegex(@NotNull LexerRegex regex, int priority) {
 		REGEX    = regex;
 		PRIORITY = priority;
 	}
 	
 	/**
-	 * @see com.adacore.adaintellij.lexanalysis.regex.OORegex#nullable()
+	 * @see com.adacore.adaintellij.lexanalysis.regex.LexerRegex#nullable()
 	 */
 	@Override
 	public boolean nullable() { return true; }
 	
 	/**
-	 * @see com.adacore.adaintellij.lexanalysis.regex.OORegex#charactersMatched()
+	 * @see com.adacore.adaintellij.lexanalysis.regex.LexerRegex#charactersMatched()
 	 */
 	@Override
 	public int charactersMatched() { return -1; }
 	
 	/**
-	 * @see com.adacore.adaintellij.lexanalysis.regex.OORegex#getPriority()
+	 * @see com.adacore.adaintellij.lexanalysis.regex.LexerRegex#getPriority()
 	 */
 	@Override
 	public int getPriority() { return PRIORITY; }
 	
 	/**
-	 * @see com.adacore.adaintellij.lexanalysis.regex.OORegex#advanced(char)
+	 * @see com.adacore.adaintellij.lexanalysis.regex.LexerRegex#advanced(char)
 	 */
 	@Nullable
 	@Override
-	public OORegex advanced(char character) { return REGEX.advanced(character); }
+	public LexerRegex advanced(char character) { return REGEX.advanced(character); }
 	
 }

--- a/src/test/control/com/adacore/adaintellij/lexanalysis/AdaLexerTest.java
+++ b/src/test/control/com/adacore/adaintellij/lexanalysis/AdaLexerTest.java
@@ -1,17 +1,13 @@
 package com.adacore.adaintellij.lexanalysis;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 import java.net.URI;
 import java.util.*;
 
-import com.intellij.lexer.Lexer;
-import com.intellij.psi.tree.IElementType;
+import org.junit.jupiter.api.Test;
 
 import com.adacore.adaintellij.AdaTestUtils;
-import com.adacore.adaintellij.lexanalysis.AdaTokenListParser.TokenData;
 
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * JUnit test class for the AdaLexer class.
@@ -39,30 +35,21 @@ final class AdaLexerTest {
 		
 		String sourceText = AdaTestUtils.getFileText(sourceFileURI);
 		
-		Iterator<TokenData> expectedTokens = AdaTokenListParser.parseTokenListFile(tokenListFileURI);
-		
-		Lexer lexer = new AdaLexer();
+		Iterator<AdaLexer.Token> expectedTokens = AdaTokenListParser.parseTokenListFile(tokenListFileURI);
+		Iterator<AdaLexer.Token> textTokens     = AdaLexer.textTokens(sourceText);
 		
 		// Testing
 		
-		lexer.start(sourceText, 0, sourceText.length(), 0);
-		
-		IElementType tokenType = lexer.getTokenType();
-		
-		while (tokenType != null) {
+		while (textTokens.hasNext()) {
 			
-			TokenData lexerTokenData =
-				new TokenData(tokenType.toString(), lexer.getTokenStart(), lexer.getTokenEnd());
+			AdaLexer.Token lexerToken =
+				textTokens.next();
 			
 			if (!expectedTokens.hasNext()) {
-				fail("Reached end of token list but lexer generated another token:\n\t" + lexerTokenData);
+				fail("Reached end of token list but lexer generated another token:\n\t" + lexerToken);
 			}
 			
-			assertEquals(expectedTokens.next(), lexerTokenData);
-			
-			lexer.advance();
-			
-			tokenType = lexer.getTokenType();
+			assertEquals(expectedTokens.next(), lexerToken);
 			
 		}
 		
@@ -80,6 +67,46 @@ final class AdaLexerTest {
 		assertSourceFileLexedCorrectly(
 			classObject.getResource("/ada-sources/empty.adb").toURI(),
 			classObject.getResource("/ada-sources/empty.adb.token-list").toURI()
+		);
+	}
+	
+	// Testing lexing delimiters
+	
+	@Test
+	void source_file_with_delimiters_lexed_correctly() throws Exception {
+		assertSourceFileLexedCorrectly(
+			classObject.getResource("/ada-sources/delimiters.adb").toURI(),
+			classObject.getResource("/ada-sources/delimiters.adb.token-list").toURI()
+		);
+	}
+	
+	// Testing lexing literals
+	
+	@Test
+	void source_file_with_literals_lexed_correctly() throws Exception {
+		assertSourceFileLexedCorrectly(
+			classObject.getResource("/ada-sources/literals.adb").toURI(),
+			classObject.getResource("/ada-sources/literals.adb.token-list").toURI()
+		);
+	}
+	
+	// Testing lexing keywords
+	
+	@Test
+	void source_file_with_keywords_lexed_correctly() throws Exception {
+		assertSourceFileLexedCorrectly(
+			classObject.getResource("/ada-sources/keywords.adb").toURI(),
+			classObject.getResource("/ada-sources/keywords.adb.token-list").toURI()
+		);
+	}
+	
+	// Testing lexing bad syntax
+	
+	@Test
+	void source_file_with_bad_syntax_lexed_correctly() throws Exception {
+		assertSourceFileLexedCorrectly(
+			classObject.getResource("/ada-sources/bad-syntax.adb").toURI(),
+			classObject.getResource("/ada-sources/bad-syntax.adb.token-list").toURI()
 		);
 	}
 	
@@ -108,26 +135,6 @@ final class AdaLexerTest {
 		assertSourceFileLexedCorrectly(
 			classObject.getResource("/ada-sources/code-with-comments.adb").toURI(),
 			classObject.getResource("/ada-sources/code-with-comments.adb.token-list").toURI()
-		);
-	}
-	
-	// Testing lexing literals
-	
-	@Test
-	void source_file_with_literals_lexed_correctly() throws Exception {
-		assertSourceFileLexedCorrectly(
-			classObject.getResource("/ada-sources/literals.adb").toURI(),
-			classObject.getResource("/ada-sources/literals.adb.token-list").toURI()
-		);
-	}
-	
-	// Testing lexing bad syntax
-	
-	@Test
-	void source_file_with_bad_syntax_lexed_correctly() throws Exception {
-		assertSourceFileLexedCorrectly(
-			classObject.getResource("/ada-sources/bad-syntax.adb").toURI(),
-			classObject.getResource("/ada-sources/bad-syntax.adb.token-list").toURI()
 		);
 	}
 	

--- a/src/test/control/com/adacore/adaintellij/lexanalysis/regex/ConcatenationRegexTest.java
+++ b/src/test/control/com/adacore/adaintellij/lexanalysis/regex/ConcatenationRegexTest.java
@@ -1,42 +1,42 @@
 package com.adacore.adaintellij.lexanalysis.regex;
 
-import static org.junit.jupiter.api.Assertions.*;
-
-import static com.adacore.adaintellij.lexanalysis.regex.OORegexTestUtils.*;
-
 import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.*;
+
+import static com.adacore.adaintellij.lexanalysis.regex.LexerRegexTestUtils.*;
+
 /**
- * JUnit test class for the ConcatRegex class.
+ * JUnit test class for the ConcatenationRegex class.
  */
-final class ConcatRegexTest {
+final class ConcatenationRegexTest {
 	
 	// Constants
 	
-	private static final OORegex LOWER_CASE_A_UNIT_REGEX = new UnitRegex("a");
-	private static final OORegex LOWER_CASE_B_UNIT_REGEX = new UnitRegex("b");
-	private static final OORegex LOWER_CASE_C_UNIT_REGEX = new UnitRegex("c");
-	private static final OORegex LOWER_CASE_D_UNIT_REGEX = new UnitRegex("d");
-	private static final OORegex LOWER_CASE_E_UNIT_REGEX = new UnitRegex("e");
+	private static final LexerRegex LOWER_CASE_A_UNIT_REGEX = new UnitRegex("a");
+	private static final LexerRegex LOWER_CASE_B_UNIT_REGEX = new UnitRegex("b");
+	private static final LexerRegex LOWER_CASE_C_UNIT_REGEX = new UnitRegex("c");
+	private static final LexerRegex LOWER_CASE_D_UNIT_REGEX = new UnitRegex("d");
+	private static final LexerRegex LOWER_CASE_E_UNIT_REGEX = new UnitRegex("e");
 	
-	private static final OORegex CONCAT_REGEX_1 =
-		ConcatRegex.fromRegexes(
+	private static final LexerRegex CONCAT_REGEX_1 =
+		ConcatenationRegex.fromRegexes(
 			LOWER_CASE_A_UNIT_REGEX,
 			LOWER_CASE_B_UNIT_REGEX,
 			LOWER_CASE_C_UNIT_REGEX
 		);
 	
-	private static final OORegex CONCAT_REGEX_2 =
-		ConcatRegex.fromRegexes(
+	private static final LexerRegex CONCAT_REGEX_2 =
+		ConcatenationRegex.fromRegexes(
 			new UnitRegex("ab"),
 			new UnitRegex("cd")
 		);
 	
-	private static final OORegex CONCAT_REGEX_3 =
-		ConcatRegex.fromRegexes(
+	private static final LexerRegex CONCAT_REGEX_3 =
+		ConcatenationRegex.fromRegexes(
 			new UnitRegex("hello"),
 			new UnitRegex("world")
 		);
@@ -48,7 +48,7 @@ final class ConcatRegexTest {
 		
 		// Initialization
 		
-		List<OORegex> regexes = new ArrayList<>();
+		List<LexerRegex> regexes = new ArrayList<>();
 		
 		regexes.add(LOWER_CASE_A_UNIT_REGEX);
 		regexes.add(LOWER_CASE_B_UNIT_REGEX);
@@ -58,15 +58,15 @@ final class ConcatRegexTest {
 		
 		// Testing
 		
-		assertTrue(ConcatRegex.fromList(regexes) instanceof ConcatRegex);
+		assertTrue(ConcatenationRegex.fromList(regexes) instanceof ConcatenationRegex);
 		
-		assertTrue(ConcatRegex.fromRegexes(
+		assertTrue(ConcatenationRegex.fromRegexes(
 			LOWER_CASE_A_UNIT_REGEX,
 			LOWER_CASE_B_UNIT_REGEX,
 			LOWER_CASE_C_UNIT_REGEX,
 			LOWER_CASE_D_UNIT_REGEX,
 			LOWER_CASE_E_UNIT_REGEX
-		) instanceof ConcatRegex);
+		) instanceof ConcatenationRegex);
 		
 	}
 	
@@ -77,19 +77,19 @@ final class ConcatRegexTest {
 		
 		int regexCount = 5;
 		
-		List<OORegex> regexes = new ArrayList<>();
+		List<LexerRegex> regexes = new ArrayList<>();
 		
 		for (int i = 0 ; i < regexCount ; i++) {
 			regexes.add(new UnitRegex(""));
 		}
 		
-		OORegex regex = ConcatRegex.fromList(regexes);
+		LexerRegex regex = ConcatenationRegex.fromList(regexes);
 		
 		// Testing
 		
 		for (int i = 0 ; i < regexCount - 1 ; i++) {
 			
-			ConcatRegex concatRegex = (ConcatRegex)regex;
+			ConcatenationRegex concatRegex = (ConcatenationRegex)regex;
 			
 			assertNotNull(concatRegex);
 			assertEquals(regexes.get(i), concatRegex.FIRST_REGEX);
@@ -107,8 +107,8 @@ final class ConcatRegexTest {
 		
 		// Initialization
 		
-		ConcatRegex regex =
-			(ConcatRegex)ConcatRegex.fromRegexes(
+		ConcatenationRegex regex =
+			(ConcatenationRegex) ConcatenationRegex.fromRegexes(
 				LOWER_CASE_A_UNIT_REGEX,
 				LOWER_CASE_B_UNIT_REGEX,
 				LOWER_CASE_C_UNIT_REGEX,
@@ -119,36 +119,36 @@ final class ConcatRegexTest {
 		// Testing
 		
 		assertEquals(LOWER_CASE_A_UNIT_REGEX, regex.FIRST_REGEX);
-		regex = (ConcatRegex)regex.SECOND_REGEX;
+		regex = (ConcatenationRegex)regex.SECOND_REGEX;
 		assertEquals(LOWER_CASE_B_UNIT_REGEX, regex.FIRST_REGEX);
-		regex = (ConcatRegex)regex.SECOND_REGEX;
+		regex = (ConcatenationRegex)regex.SECOND_REGEX;
 		assertEquals(LOWER_CASE_C_UNIT_REGEX, regex.FIRST_REGEX);
-		regex = (ConcatRegex)regex.SECOND_REGEX;
+		regex = (ConcatenationRegex)regex.SECOND_REGEX;
 		assertEquals(LOWER_CASE_D_UNIT_REGEX, regex.FIRST_REGEX);
 		assertEquals(LOWER_CASE_E_UNIT_REGEX, regex.SECOND_REGEX);
 		
 	}
 	
-	// Testing ConcatRegex#nullable() method
+	// Testing ConcatenationRegex#nullable() method
 	
 	@Test
 	void concat_regex_is_nullable_iff_both_subregexes_are_nullable() {
 		
 		// Initialization
 		
-		OORegex nullableRegex    = new UnitRegex("");
-		OORegex nonNullableRegex = new UnitRegex("abc");
+		LexerRegex nullableRegex    = new UnitRegex("");
+		LexerRegex nonNullableRegex = new UnitRegex("abc");
 		
 		// Testing
 		
-		assertFalse(new ConcatRegex(nonNullableRegex, nonNullableRegex).nullable());
-		assertFalse(new ConcatRegex(nonNullableRegex, nullableRegex).nullable());
-		assertFalse(new ConcatRegex(nullableRegex, nonNullableRegex).nullable());
-		assertTrue(new ConcatRegex(nullableRegex, nullableRegex).nullable());
+		assertFalse(new ConcatenationRegex(nonNullableRegex, nonNullableRegex).nullable());
+		assertFalse(new ConcatenationRegex(nonNullableRegex, nullableRegex).nullable());
+		assertFalse(new ConcatenationRegex(nullableRegex, nonNullableRegex).nullable());
+		assertTrue(new ConcatenationRegex(nullableRegex, nullableRegex).nullable());
 		
 	}
 	
-	// Testing ConcatRegex#advanced(char) method
+	// Testing ConcatenationRegex#advanced(char) method
 	
 	@Test
 	void concat_regex_does_not_advance_when_it_should_not() {

--- a/src/test/control/com/adacore/adaintellij/lexanalysis/regex/GeneralCategoryRegexTest.java
+++ b/src/test/control/com/adacore/adaintellij/lexanalysis/regex/GeneralCategoryRegexTest.java
@@ -1,10 +1,10 @@
 package com.adacore.adaintellij.lexanalysis.regex;
 
+import org.junit.jupiter.api.Test;
+
 import static org.junit.jupiter.api.Assertions.*;
 
-import static com.adacore.adaintellij.lexanalysis.regex.OORegexTestUtils.*;
-
-import org.junit.jupiter.api.Test;
+import static com.adacore.adaintellij.lexanalysis.regex.LexerRegexTestUtils.*;
 
 /**
  * JUnit test class for the GeneralCategoryRegex class.
@@ -13,36 +13,36 @@ final class GeneralCategoryRegexTest {
 	
 	// Constants
 	
-	private static final OORegex MARK_SPACING_COMBINING_REGEX    = new GeneralCategoryRegex("Mc");
-	private static final OORegex PUNCTUATION_CONNECTOR_REGEX     = new GeneralCategoryRegex("Pc");
-	private static final OORegex OTHER_CONTROL_REGEX             = new GeneralCategoryRegex("Cc");
-	private static final OORegex SYMBOL_CURRENCY_REGEX           = new GeneralCategoryRegex("Sc");
-	private static final OORegex PUNCTUATION_DASH_REGEX          = new GeneralCategoryRegex("Pd");
-	private static final OORegex NUMBER_DECIMAL_REGEX            = new GeneralCategoryRegex("Nd");
-	private static final OORegex MARK_ENCLOSING_REGEX            = new GeneralCategoryRegex("Me");
-	private static final OORegex PUNCTUATION_END_REGEX           = new GeneralCategoryRegex("Pe");
-	private static final OORegex PUNCTUATION_FINAL_QUOTE_REGEX   = new GeneralCategoryRegex("Pf");
-	private static final OORegex OTHER_FORMAT_REGEX              = new GeneralCategoryRegex("Cf");
-	private static final OORegex PUNCTUATION_INITIAL_QUOTE_REGEX = new GeneralCategoryRegex("Pi");
-	private static final OORegex NUMBER_LETTER_REGEX             = new GeneralCategoryRegex("Nl");
-	private static final OORegex SEPARATOR_LINE_REGEX            = new GeneralCategoryRegex("Zl");
-	private static final OORegex LETTER_LOWERCASE_REGEX          = new GeneralCategoryRegex("Ll");
-	private static final OORegex SYMBOL_MATH_REGEX               = new GeneralCategoryRegex("Sm");
-	private static final OORegex LETTER_MODIFIER_REGEX           = new GeneralCategoryRegex("Lm");
-	private static final OORegex SYMBOL_MODIFIER_REGEX           = new GeneralCategoryRegex("Sk");
-	private static final OORegex MARK_NON_SPACING_REGEX          = new GeneralCategoryRegex("Mn");
-	private static final OORegex LETTER_OTHER_REGEX              = new GeneralCategoryRegex("Lo");
-	private static final OORegex NUMBER_OTHER_REGEX              = new GeneralCategoryRegex("No");
-	private static final OORegex PUNCTUATION_OTHER_REGEX         = new GeneralCategoryRegex("Po");
-	private static final OORegex SYMBOL_OTHER_REGEX              = new GeneralCategoryRegex("So");
-	private static final OORegex SEPARATOR_PARAGRAPH_REGEX       = new GeneralCategoryRegex("Zp");
-	private static final OORegex OTHER_PRIVATE_USE_REGEX         = new GeneralCategoryRegex("Co");
-	private static final OORegex SEPARATOR_SPACE_REGEX           = new GeneralCategoryRegex("Zs");
-	private static final OORegex PUNCTUATION_START_REGEX         = new GeneralCategoryRegex("Ps");
-	private static final OORegex OTHER_SURROGATE_REGEX           = new GeneralCategoryRegex("Cs");
-	private static final OORegex LETTER_TITLECASE_REGEX          = new GeneralCategoryRegex("Lt");
-	private static final OORegex OTHER_UNASSIGNED_REGEX          = new GeneralCategoryRegex("Cn");
-	private static final OORegex LETTER_UPPERCASE_REGEX          = new GeneralCategoryRegex("Lu");
+	private static final LexerRegex MARK_SPACING_COMBINING_REGEX    = new GeneralCategoryRegex("Mc");
+	private static final LexerRegex PUNCTUATION_CONNECTOR_REGEX     = new GeneralCategoryRegex("Pc");
+	private static final LexerRegex OTHER_CONTROL_REGEX             = new GeneralCategoryRegex("Cc");
+	private static final LexerRegex SYMBOL_CURRENCY_REGEX           = new GeneralCategoryRegex("Sc");
+	private static final LexerRegex PUNCTUATION_DASH_REGEX          = new GeneralCategoryRegex("Pd");
+	private static final LexerRegex NUMBER_DECIMAL_REGEX            = new GeneralCategoryRegex("Nd");
+	private static final LexerRegex MARK_ENCLOSING_REGEX            = new GeneralCategoryRegex("Me");
+	private static final LexerRegex PUNCTUATION_END_REGEX           = new GeneralCategoryRegex("Pe");
+	private static final LexerRegex PUNCTUATION_FINAL_QUOTE_REGEX   = new GeneralCategoryRegex("Pf");
+	private static final LexerRegex OTHER_FORMAT_REGEX              = new GeneralCategoryRegex("Cf");
+	private static final LexerRegex PUNCTUATION_INITIAL_QUOTE_REGEX = new GeneralCategoryRegex("Pi");
+	private static final LexerRegex NUMBER_LETTER_REGEX             = new GeneralCategoryRegex("Nl");
+	private static final LexerRegex SEPARATOR_LINE_REGEX            = new GeneralCategoryRegex("Zl");
+	private static final LexerRegex LETTER_LOWERCASE_REGEX          = new GeneralCategoryRegex("Ll");
+	private static final LexerRegex SYMBOL_MATH_REGEX               = new GeneralCategoryRegex("Sm");
+	private static final LexerRegex LETTER_MODIFIER_REGEX           = new GeneralCategoryRegex("Lm");
+	private static final LexerRegex SYMBOL_MODIFIER_REGEX           = new GeneralCategoryRegex("Sk");
+	private static final LexerRegex MARK_NON_SPACING_REGEX          = new GeneralCategoryRegex("Mn");
+	private static final LexerRegex LETTER_OTHER_REGEX              = new GeneralCategoryRegex("Lo");
+	private static final LexerRegex NUMBER_OTHER_REGEX              = new GeneralCategoryRegex("No");
+	private static final LexerRegex PUNCTUATION_OTHER_REGEX         = new GeneralCategoryRegex("Po");
+	private static final LexerRegex SYMBOL_OTHER_REGEX              = new GeneralCategoryRegex("So");
+	private static final LexerRegex SEPARATOR_PARAGRAPH_REGEX       = new GeneralCategoryRegex("Zp");
+	private static final LexerRegex OTHER_PRIVATE_USE_REGEX         = new GeneralCategoryRegex("Co");
+	private static final LexerRegex SEPARATOR_SPACE_REGEX           = new GeneralCategoryRegex("Zs");
+	private static final LexerRegex PUNCTUATION_START_REGEX         = new GeneralCategoryRegex("Ps");
+	private static final LexerRegex OTHER_SURROGATE_REGEX           = new GeneralCategoryRegex("Cs");
+	private static final LexerRegex LETTER_TITLECASE_REGEX          = new GeneralCategoryRegex("Lt");
+	private static final LexerRegex OTHER_UNASSIGNED_REGEX          = new GeneralCategoryRegex("Cn");
+	private static final LexerRegex LETTER_UPPERCASE_REGEX          = new GeneralCategoryRegex("Lu");
 	
 	// Testing GeneralCategoryRegex#nullable() method
 	

--- a/src/test/control/com/adacore/adaintellij/lexanalysis/regex/IntersectionRegexTest.java
+++ b/src/test/control/com/adacore/adaintellij/lexanalysis/regex/IntersectionRegexTest.java
@@ -1,10 +1,10 @@
 package com.adacore.adaintellij.lexanalysis.regex;
 
+import org.junit.jupiter.api.Test;
+
 import static org.junit.jupiter.api.Assertions.*;
 
-import static com.adacore.adaintellij.lexanalysis.regex.OORegexTestUtils.*;
-
-import org.junit.jupiter.api.Test;
+import static com.adacore.adaintellij.lexanalysis.regex.LexerRegexTestUtils.*;
 
 /**
  * JUnit test class for the IntersectionRegex class.
@@ -14,7 +14,7 @@ final class IntersectionRegexTest {
 	// Constants
 	
 	// All lowercase letters except the letters "h", "e", "l" and "o"
-	private static final OORegex INTERSECTION_REGEX_1 =
+	private static final LexerRegex INTERSECTION_REGEX_1 =
 		new IntersectionRegex(
 			UnionRegex.fromRange('a', 'z'),
 			new NotRegex(
@@ -29,14 +29,14 @@ final class IntersectionRegexTest {
 	
 	// Equivalent to "h" but written as an intersection of
 	// "hello" and "h"
-	private static final OORegex INTERSECTION_REGEX_2 =
+	private static final LexerRegex INTERSECTION_REGEX_2 =
 		new IntersectionRegex(
 			new UnitRegex("hello"),
 			new UnitRegex("helicopter")
 		);
 	
 	// Parentheses only"
-	private static final OORegex INTERSECTION_REGEX_3 =
+	private static final LexerRegex INTERSECTION_REGEX_3 =
 		new IntersectionRegex(
 			UnionRegex.fromRegexes(
 				new UnitRegex("*"),
@@ -61,8 +61,8 @@ final class IntersectionRegexTest {
 		
 		// Initialization
 		
-		OORegex nullableRegex    = new UnitRegex("");
-		OORegex nonNullableRegex = new UnitRegex("abc");
+		LexerRegex nullableRegex    = new UnitRegex("");
+		LexerRegex nonNullableRegex = new UnitRegex("abc");
 		
 		// Testing
 		

--- a/src/test/control/com/adacore/adaintellij/lexanalysis/regex/LexerRegexTestUtils.java
+++ b/src/test/control/com/adacore/adaintellij/lexanalysis/regex/LexerRegexTestUtils.java
@@ -5,7 +5,7 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * Helper testing methods for regex classes.
  */
-final class OORegexTestUtils {
+final class LexerRegexTestUtils {
 	
 	/**
 	 * Represents the result of applying a regex to a sequence of characters.
@@ -34,9 +34,9 @@ final class OORegexTestUtils {
 	 * @param sequence The sequence of characters.
 	 * @return The advance state.
 	 */
-	private static AdvanceState regexAdvanceStateOnSequence(OORegex regex, String sequence) {
+	private static AdvanceState regexAdvanceStateOnSequence(LexerRegex regex, String sequence) {
 		
-		OORegex advancedRegex = regex;
+		LexerRegex advancedRegex = regex;
 		
 		for (char character : sequence.toCharArray()) {
 			advancedRegex = advancedRegex.advanced(character);
@@ -55,7 +55,7 @@ final class OORegexTestUtils {
 	 * @param regex The regex to advance.
 	 * @param sequence The sequence of characters.
 	 */
-	static void assertRegexAdvances(OORegex regex, String sequence) {
+	static void assertRegexAdvances(LexerRegex regex, String sequence) {
 		assertNotEquals(
 			AdvanceState.DOES_NOT_ADVANCE_ON_SEQUENCE,
 			regexAdvanceStateOnSequence(regex, sequence)
@@ -69,7 +69,7 @@ final class OORegexTestUtils {
 	 * @param regex The regex to advance.
 	 * @param sequence The sequence of characters.
 	 */
-	static void assertRegexDoesNotAdvance(OORegex regex, String sequence) {
+	static void assertRegexDoesNotAdvance(LexerRegex regex, String sequence) {
 		assertEquals(
 			AdvanceState.DOES_NOT_ADVANCE_ON_SEQUENCE,
 			regexAdvanceStateOnSequence(regex, sequence)
@@ -83,7 +83,7 @@ final class OORegexTestUtils {
 	 * @param regex The regex to advance.
 	 * @param sequence The sequence of characters.
 	 */
-	static void assertRegexMatches(OORegex regex, String sequence) {
+	static void assertRegexMatches(LexerRegex regex, String sequence) {
 		assertEquals(
 			AdvanceState.MATCHES_SEQUENCE,
 			regexAdvanceStateOnSequence(regex, sequence)
@@ -97,7 +97,7 @@ final class OORegexTestUtils {
 	 * @param regex The regex to advance.
 	 * @param sequence The sequence of characters.
 	 */
-	static void assertRegexDoesNotMatch(OORegex regex, String sequence) {
+	static void assertRegexDoesNotMatch(LexerRegex regex, String sequence) {
 		assertNotEquals(
 			AdvanceState.MATCHES_SEQUENCE,
 			regexAdvanceStateOnSequence(regex, sequence)

--- a/src/test/control/com/adacore/adaintellij/lexanalysis/regex/NotRegexTest.java
+++ b/src/test/control/com/adacore/adaintellij/lexanalysis/regex/NotRegexTest.java
@@ -1,10 +1,10 @@
 package com.adacore.adaintellij.lexanalysis.regex;
 
+import org.junit.jupiter.api.Test;
+
 import static org.junit.jupiter.api.Assertions.*;
 
-import static com.adacore.adaintellij.lexanalysis.regex.OORegexTestUtils.*;
-
-import org.junit.jupiter.api.Test;
+import static com.adacore.adaintellij.lexanalysis.regex.LexerRegexTestUtils.*;
 
 /**
  * JUnit test class for the NotRegex class.
@@ -13,8 +13,8 @@ final class NotRegexTest {
 	
 	// Constants
 	
-	private static final OORegex NOT_LOWERCASE_A_REGEX      = new NotRegex(new UnitRegex("a"));
-	private static final OORegex NOT_LOWERCASE_LETTER_REGEX = new NotRegex(UnionRegex.fromRange('a', 'z'));
+	private static final LexerRegex NOT_LOWERCASE_A_REGEX      = new NotRegex(new UnitRegex("a"));
+	private static final LexerRegex NOT_LOWERCASE_LETTER_REGEX = new NotRegex(UnionRegex.fromRange('a', 'z'));
 	
 	// Testing NotRegex#nullable() method
 	

--- a/src/test/control/com/adacore/adaintellij/lexanalysis/regex/OneOrMoreRegexTest.java
+++ b/src/test/control/com/adacore/adaintellij/lexanalysis/regex/OneOrMoreRegexTest.java
@@ -1,10 +1,10 @@
 package com.adacore.adaintellij.lexanalysis.regex;
 
+import org.junit.jupiter.api.Test;
+
 import static org.junit.jupiter.api.Assertions.*;
 
-import static com.adacore.adaintellij.lexanalysis.regex.OORegexTestUtils.*;
-
-import org.junit.jupiter.api.Test;
+import static com.adacore.adaintellij.lexanalysis.regex.LexerRegexTestUtils.*;
 
 /**
  * JUnit test class for the OneOrMoreRegex class.
@@ -13,17 +13,17 @@ final class OneOrMoreRegexTest {
 	
 	// Constants
 	
-	private static final OORegex ONE_OR_MORE_LOWERCASE_A_REGEX = new OneOrMoreRegex(new UnitRegex("a"));
+	private static final LexerRegex ONE_OR_MORE_LOWERCASE_A_REGEX = new OneOrMoreRegex(new UnitRegex("a"));
 	
-	private static final OORegex ONE_OR_MORE_BRACKETS_REGEX =
+	private static final LexerRegex ONE_OR_MORE_BRACKETS_REGEX =
 		new OneOrMoreRegex(
-			new ConcatRegex(
+			new ConcatenationRegex(
 				new UnionRegex(new UnitRegex("["), new UnitRegex("{")),
 				new UnionRegex(new UnitRegex("]"), new UnitRegex("}"))
 			)
 		);
 	
-	private static final OORegex ONE_OR_MORE_NULLABLE_REGEX =
+	private static final LexerRegex ONE_OR_MORE_NULLABLE_REGEX =
 		new OneOrMoreRegex(
 			new UnionRegex(
 				new UnitRegex("abc"),

--- a/src/test/control/com/adacore/adaintellij/lexanalysis/regex/UnionRegexTest.java
+++ b/src/test/control/com/adacore/adaintellij/lexanalysis/regex/UnionRegexTest.java
@@ -1,12 +1,12 @@
 package com.adacore.adaintellij.lexanalysis.regex;
 
-import static org.junit.jupiter.api.Assertions.*;
-
-import static com.adacore.adaintellij.lexanalysis.regex.OORegexTestUtils.*;
-
 import java.util.*;
 
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import static com.adacore.adaintellij.lexanalysis.regex.LexerRegexTestUtils.*;
 
 /**
  * JUnit test class for the UnionRegex class.
@@ -15,26 +15,26 @@ final class UnionRegexTest {
 	
 	// Constants
 	
-	private static final OORegex LOWER_CASE_A_UNIT_REGEX = new UnitRegex("a");
-	private static final OORegex LOWER_CASE_B_UNIT_REGEX = new UnitRegex("b");
-	private static final OORegex LOWER_CASE_C_UNIT_REGEX = new UnitRegex("c");
-	private static final OORegex LOWER_CASE_D_UNIT_REGEX = new UnitRegex("d");
-	private static final OORegex LOWER_CASE_E_UNIT_REGEX = new UnitRegex("e");
+	private static final LexerRegex LOWER_CASE_A_UNIT_REGEX = new UnitRegex("a");
+	private static final LexerRegex LOWER_CASE_B_UNIT_REGEX = new UnitRegex("b");
+	private static final LexerRegex LOWER_CASE_C_UNIT_REGEX = new UnitRegex("c");
+	private static final LexerRegex LOWER_CASE_D_UNIT_REGEX = new UnitRegex("d");
+	private static final LexerRegex LOWER_CASE_E_UNIT_REGEX = new UnitRegex("e");
 	
-	private static final OORegex UNION_REGEX_1 =
+	private static final LexerRegex UNION_REGEX_1 =
 		UnionRegex.fromRegexes(
 			LOWER_CASE_A_UNIT_REGEX,
 			LOWER_CASE_B_UNIT_REGEX,
 			LOWER_CASE_C_UNIT_REGEX
 		);
 	
-	private static final OORegex UNION_REGEX_2 =
+	private static final LexerRegex UNION_REGEX_2 =
 		UnionRegex.fromRegexes(
 			new UnitRegex("abc"),
 			new UnitRegex("cba")
 		);
 	
-	private static final OORegex UNION_REGEX_3 =
+	private static final LexerRegex UNION_REGEX_3 =
 		UnionRegex.fromRegexes(
 			new UnitRegex("hello"),
 			new UnitRegex("h")
@@ -47,7 +47,7 @@ final class UnionRegexTest {
 		
 		// Initialization
 		
-		List<OORegex> regexes = new ArrayList<>();
+		List<LexerRegex> regexes = new ArrayList<>();
 		
 		regexes.add(LOWER_CASE_A_UNIT_REGEX);
 		regexes.add(LOWER_CASE_B_UNIT_REGEX);
@@ -78,13 +78,13 @@ final class UnionRegexTest {
 		
 		int regexCount = 5;
 		
-		List<OORegex> regexes = new ArrayList<>();
+		List<LexerRegex> regexes = new ArrayList<>();
 		
 		for (int i = 0 ; i < regexCount ; i++) {
 			regexes.add(new UnitRegex(""));
 		}
 		
-		OORegex regex = UnionRegex.fromList(regexes);
+		LexerRegex regex = UnionRegex.fromList(regexes);
 		
 		// Testing
 		
@@ -157,8 +157,8 @@ final class UnionRegexTest {
 		
 		// Initialization
 		
-		OORegex nullableRegex    = new UnitRegex("");
-		OORegex nonNullableRegex = new UnitRegex("abc");
+		LexerRegex nullableRegex    = new UnitRegex("");
+		LexerRegex nonNullableRegex = new UnitRegex("abc");
 		
 		// Testing
 		

--- a/src/test/control/com/adacore/adaintellij/lexanalysis/regex/UnitRegexTest.java
+++ b/src/test/control/com/adacore/adaintellij/lexanalysis/regex/UnitRegexTest.java
@@ -1,10 +1,10 @@
 package com.adacore.adaintellij.lexanalysis.regex;
 
+import org.junit.jupiter.api.Test;
+
 import static org.junit.jupiter.api.Assertions.*;
 
-import static com.adacore.adaintellij.lexanalysis.regex.OORegexTestUtils.*;
-
-import org.junit.jupiter.api.Test;
+import static com.adacore.adaintellij.lexanalysis.regex.LexerRegexTestUtils.*;
 
 /**
  * JUnit test class for the UnitRegex class.
@@ -13,8 +13,8 @@ final class UnitRegexTest {
 	
 	// Constants
 	
-	private static final OORegex EMPTY_UNIT_REGEX         = new UnitRegex("");
-	private static final OORegex LOWERCASE_ABC_UNIT_REGEX = new UnitRegex("abc");
+	private static final LexerRegex EMPTY_UNIT_REGEX         = new UnitRegex("");
+	private static final LexerRegex LOWERCASE_ABC_UNIT_REGEX = new UnitRegex("abc");
 	
 	// Testing UnitRegex#nullable() method
 	

--- a/src/test/control/com/adacore/adaintellij/lexanalysis/regex/ZeroOrMoreRegexTest.java
+++ b/src/test/control/com/adacore/adaintellij/lexanalysis/regex/ZeroOrMoreRegexTest.java
@@ -1,10 +1,10 @@
 package com.adacore.adaintellij.lexanalysis.regex;
 
+import org.junit.jupiter.api.Test;
+
 import static org.junit.jupiter.api.Assertions.*;
 
-import static com.adacore.adaintellij.lexanalysis.regex.OORegexTestUtils.*;
-
-import org.junit.jupiter.api.Test;
+import static com.adacore.adaintellij.lexanalysis.regex.LexerRegexTestUtils.*;
 
 /**
  * JUnit test class for the ZeroOrMoreRegex class.
@@ -13,17 +13,17 @@ final class ZeroOrMoreRegexTest {
 	
 	// Constants
 	
-	private static final OORegex ZERO_OR_MORE_LOWERCASE_A_REGEX = new ZeroOrMoreRegex(new UnitRegex("a"));
+	private static final LexerRegex ZERO_OR_MORE_LOWERCASE_A_REGEX = new ZeroOrMoreRegex(new UnitRegex("a"));
 	
-	private static final OORegex ZERO_OR_MORE_BRACKETS_REGEX =
+	private static final LexerRegex ZERO_OR_MORE_BRACKETS_REGEX =
 		new ZeroOrMoreRegex(
-			new ConcatRegex(
+			new ConcatenationRegex(
 				new UnionRegex(new UnitRegex("["), new UnitRegex("{")),
 				new UnionRegex(new UnitRegex("]"), new UnitRegex("}"))
 			)
 		);
 	
-	private static final OORegex ZERO_OR_MORE_NULLABLE_REGEX =
+	private static final LexerRegex ZERO_OR_MORE_NULLABLE_REGEX =
 		new ZeroOrMoreRegex(
 			new UnionRegex(
 				new UnitRegex("abc"),

--- a/src/test/control/com/adacore/adaintellij/lexanalysis/regex/ZeroOrOneRegexTest.java
+++ b/src/test/control/com/adacore/adaintellij/lexanalysis/regex/ZeroOrOneRegexTest.java
@@ -1,10 +1,10 @@
 package com.adacore.adaintellij.lexanalysis.regex;
 
+import org.junit.jupiter.api.Test;
+
 import static org.junit.jupiter.api.Assertions.*;
 
-import static com.adacore.adaintellij.lexanalysis.regex.OORegexTestUtils.*;
-
-import org.junit.jupiter.api.Test;
+import static com.adacore.adaintellij.lexanalysis.regex.LexerRegexTestUtils.*;
 
 /**
  * JUnit test class for the ZeroOrOneRegex class.
@@ -13,17 +13,17 @@ final class ZeroOrOneRegexTest {
 	
 	// Constants
 	
-	private static final OORegex ZERO_OR_ONE_LOWERCASE_A_REGEX = new ZeroOrOneRegex(new UnitRegex("a"));
+	private static final LexerRegex ZERO_OR_ONE_LOWERCASE_A_REGEX = new ZeroOrOneRegex(new UnitRegex("a"));
 	
-	private static final OORegex ZERO_OR_ONE_BRACKETS_REGEX =
+	private static final LexerRegex ZERO_OR_ONE_BRACKETS_REGEX =
 		new ZeroOrOneRegex(
-			new ConcatRegex(
+			new ConcatenationRegex(
 				new UnionRegex(new UnitRegex("["), new UnitRegex("{")),
 				new UnionRegex(new UnitRegex("]"), new UnitRegex("}"))
 			)
 		);
 	
-	private static final OORegex ZERO_OR_ONE_NULLABLE_REGEX =
+	private static final LexerRegex ZERO_OR_ONE_NULLABLE_REGEX =
 		new ZeroOrOneRegex(
 			new UnionRegex(
 				new UnitRegex("abc"),

--- a/src/test/resources/ada-sources/bad-syntax.adb.token-list
+++ b/src/test/resources/ada-sources/bad-syntax.adb.token-list
@@ -4,130 +4,154 @@
 -- is to test the lexer's token generation for syntactically invalid
 -- sequences of characters.
 
-AdaTokenType.COMMENT           0  19 -- Comment token for "-- Numeric Literals"
+COMMENT           0  19 -- Comment token for "-- Numeric Literals"
 
-WHITE_SPACE                   19  20
+WHITE_SPACE      19  20
 
 ----------------------
 -- Numeric Literals --
 ----------------------
 
-BAD_CHARACTER                 20  24 -- 123_
-BAD_CHARACTER                 24  25 --     _
-AdaTokenType.DECIMAL_LITERAL  25  28 --      456
+DECIMAL_LITERAL  20  23 -- 123
+BAD_CHARACTER    23  24 --    _
+BAD_CHARACTER    24  25 --     _
+DECIMAL_LITERAL  25  28 --      456
 
-WHITE_SPACE                   28  29
+WHITE_SPACE      28  29
 
-BAD_CHARACTER                 29  38 -- 12345678_
+DECIMAL_LITERAL  29  37 -- 12345678
+BAD_CHARACTER    37  38 --         _
 
-WHITE_SPACE                   38  39
+WHITE_SPACE      38  39
 
-BAD_CHARACTER                 39  43 -- 123.
+DECIMAL_LITERAL  39  42 -- 123
+FULL_STOP        42  43 --    .
 
-WHITE_SPACE                   43  44
+WHITE_SPACE      43  44
 
-AdaTokenType.DECIMAL_LITERAL  44  51 -- 123.456
-AdaTokenType.FULL_STOP        51  52 --        .
-AdaTokenType.DECIMAL_LITERAL  52  55 --         789
+DECIMAL_LITERAL  44  51 -- 123.456
+FULL_STOP        51  52 --        .
+DECIMAL_LITERAL  52  55 --         789
 
-WHITE_SPACE                   55  56
+WHITE_SPACE      55  56
 
-BAD_CHARACTER                 56  59 -- 1E+
+DECIMAL_LITERAL  56  57 -- 1
+IDENTIFIER       57  58 --  E
+PLUS_SIGN        58  59 --   +
 
-WHITE_SPACE                   59  60
+WHITE_SPACE      59  60
 
-AdaTokenType.DECIMAL_LITERAL  60  67 -- 1234e56
-AdaTokenType.FULL_STOP        67  68 --        .
-AdaTokenType.DECIMAL_LITERAL  68  69 --         7
+DECIMAL_LITERAL  60  67 -- 1234e56
+FULL_STOP        67  68 --        .
+DECIMAL_LITERAL  68  69 --         7
 
-WHITE_SPACE                   69  70
+WHITE_SPACE      69  70
 
-BAD_CHARACTER                 70  73 -- 16#
+DECIMAL_LITERAL  70  72 -- 16
+BAD_CHARACTER    72  73 --   #
 
-WHITE_SPACE                   73  74
+WHITE_SPACE      73  74
 
-BAD_CHARACTER                 74  79 -- 12#14
+DECIMAL_LITERAL  74  76 -- 12
+BAD_CHARACTER    76  77 --   #
+DECIMAL_LITERAL  77  79 --    14
 
-WHITE_SPACE                   79  80
+WHITE_SPACE      79  80
 
-BAD_CHARACTER                 80  85 -- 10#5.
+DECIMAL_LITERAL  80  82 -- 10
+BAD_CHARACTER    82  83 --   #
+DECIMAL_LITERAL  83  84 --    5
+FULL_STOP        84  85 --     .
 
-WHITE_SPACE                   85  86
+WHITE_SPACE      85  86
 
-BAD_CHARACTER                 86  91 -- 8#2.3
+DECIMAL_LITERAL  86  87 -- 8
+BAD_CHARACTER    87  88 --  #
+DECIMAL_LITERAL  88  91 --   2.3
 
-WHITE_SPACE                   91  92
+WHITE_SPACE      91  92
 
-BAD_CHARACTER                 92  94 -- 6#
-BAD_CHARACTER                 94  95 --   #
+DECIMAL_LITERAL  92  93 -- 6
+BAD_CHARACTER    93  94 --  #
+BAD_CHARACTER    94  95 --   #
 
-WHITE_SPACE                   95  96
+WHITE_SPACE      95  96
 
-BAD_CHARACTER                 96 103 -- 4#123.1
-AdaTokenType.FULL_STOP       103 104 --        .
-BAD_CHARACTER                104 106 --         2#
+DECIMAL_LITERAL  96  97 -- 4
+BAD_CHARACTER    97  98 --  #
+DECIMAL_LITERAL  98 103 --   123.1
+FULL_STOP       103 104 --        .
+DECIMAL_LITERAL 104 105 --         2
+BAD_CHARACTER   105 106 --          #
 
-WHITE_SPACE                  106 107
+WHITE_SPACE     106 107
 
-BAD_CHARACTER                107 113 -- 2#101.
-BAD_CHARACTER                113 114 --       #
+DECIMAL_LITERAL 107 108 -- 2
+BAD_CHARACTER   108 109 --  #
+DECIMAL_LITERAL 109 112 --   101
+FULL_STOP       112 113 --      .
+BAD_CHARACTER   113 114 --       #
 
-WHITE_SPACE                  114 115
+WHITE_SPACE     114 115
 
-BAD_CHARACTER                115 121 -- 16#123
-AdaTokenType.IDENTIFIER      121 122 --       G
-BAD_CHARACTER                122 123 --        #
-AdaTokenType.DECIMAL_LITERAL 123 124 --         2
+DECIMAL_LITERAL 115 117 -- 16
+BAD_CHARACTER   117 118 --   #
+DECIMAL_LITERAL 118 121 --    123
+IDENTIFIER      121 122 --       G
+BAD_CHARACTER   122 123 --        #
+DECIMAL_LITERAL 123 124 --         2
 
-WHITE_SPACE                  124 126
+WHITE_SPACE     124 126
 
-AdaTokenType.COMMENT         126 145 -- Comment token for "-- Textual Literals"
+COMMENT         126 145 -- Comment token for "-- Textual Literals"
 
-WHITE_SPACE                  145 146
+WHITE_SPACE     145 146
 
 ----------------------
 -- Textual Literals --
 ----------------------
 
-AdaTokenType.APOSTROPHE      146 147 -- '
+APOSTROPHE      146 147 -- '
 
-WHITE_SPACE                  147 148
+WHITE_SPACE     147 148
 
-BAD_CHARACTER                148 150 -- ''
+APOSTROPHE      148 149 -- '
+APOSTROPHE      149 150 --  '
 
-WHITE_SPACE                  150 151
+WHITE_SPACE     150 151
 
-AdaTokenType.APOSTROPHE      151 152 -- '
-WHITE_SPACE                  152 153
-AdaTokenType.APOSTROPHE      153 154 --  	'
+APOSTROPHE      151 152 -- '
+WHITE_SPACE     152 153
+APOSTROPHE      153 154 --  	'
 
-WHITE_SPACE                  154 155
+WHITE_SPACE     154 155
 
-BAD_CHARACTER                155 157 -- 'a
-AdaTokenType.IDENTIFIER      157 158 --   b
-AdaTokenType.APOSTROPHE      158 159 --    '
+APOSTROPHE      155 156 -- '
+IDENTIFIER      156 158 --  ab
+APOSTROPHE      158 159 --    '
 
-WHITE_SPACE                  159 160
+WHITE_SPACE     159 160
 
-BAD_CHARACTER                160 161 -- "
+BAD_CHARACTER   160 161 -- "
 
-WHITE_SPACE                  161 162
+WHITE_SPACE     161 162
 
-BAD_CHARACTER                162 165 -- """
+STRING_LITERAL  162 164 -- ""
+BAD_CHARACTER   164 165 --   "
 
-WHITE_SPACE                  165 167
+WHITE_SPACE     165 167
 
-AdaTokenType.COMMENT         167 193 -- Comment token for "-- Characters not part..."
+COMMENT         167 193 -- Comment token for "-- Characters not part..."
 
-WHITE_SPACE                  193 194
+WHITE_SPACE     193 194
 
 -----------------------------
 -- Non-Alphabet Characters --
 -----------------------------
 
-AdaTokenType.IDENTIFIER      194 202 -- Put_Line
-BAD_CHARACTER                202 203 --         [
-AdaTokenType.STRING_LITERAL  203 209 --          "oops"
-BAD_CHARACTER                209 210 --                ]
+IDENTIFIER      194 202 -- Put_Line
+BAD_CHARACTER   202 203 --         [
+STRING_LITERAL  203 209 --          "oops"
+BAD_CHARACTER   209 210 --                ]
 
-WHITE_SPACE                  210 211
+WHITE_SPACE     210 211

--- a/src/test/resources/ada-sources/code-with-comments.adb
+++ b/src/test/resources/ada-sources/code-with-comments.adb
@@ -1,11 +1,12 @@
 
 -- This is an Ada single-line comment
 -- Each of these two lines should result in a separate comment token
-function test is
+function test return Integer is
 begin
 	-------------------
 	-- Function body --
 	-------------------
+	return 42;
 end test;
 
 -- This comment should represent the last token in the file

--- a/src/test/resources/ada-sources/code-with-comments.adb.token-list
+++ b/src/test/resources/ada-sources/code-with-comments.adb.token-list
@@ -1,45 +1,56 @@
 -- Token list for the "code-with-comments.adb" source file.
 -- Intended for testing token generation for Ada comments.
 
-WHITE_SPACE                     0   1
+WHITE_SPACE        0   1
 
-AdaTokenType.COMMENT            1  38 -- Comment token for "-- This is an ..."
+COMMENT            1  38 -- Comment token for "-- This is an ..."
 
-WHITE_SPACE                    38  39
+WHITE_SPACE       38  39
 
-AdaTokenType.COMMENT           39 107 -- Comment token for "-- Each of these..."
+COMMENT           39 107 -- Comment token for "-- Each of these..."
 
-WHITE_SPACE                   107 108
+WHITE_SPACE      107 108
 
-AdaTokenType.FUNCTION_KEYWORD 108 116 -- function
-WHITE_SPACE                   116 117
-AdaTokenType.IDENTIFIER       117 121 --          test
-WHITE_SPACE                   121 122
-AdaTokenType.IS_KEYWORD       122 124 --               is
+FUNCTION_KEYWORD 108 116 -- function
+WHITE_SPACE      116 117
+IDENTIFIER       117 121 --          test
+WHITE_SPACE      121 122
+RETURN_KEYWORD   122 128 --               return
+WHITE_SPACE      128 129
+IDENTIFIER       129 136 --                      Integer
+WHITE_SPACE      136 137
+IS_KEYWORD       137 139 --                              is
 
-WHITE_SPACE                   124 125
+WHITE_SPACE      139 140
 
-AdaTokenType.BEGIN_KEYWORD    125 130 -- begin
+BEGIN_KEYWORD    140 145 -- begin
 
-WHITE_SPACE                   130 132
+WHITE_SPACE      145 147
 
-AdaTokenType.COMMENT          132 151 -- Comment token for "-------------------"
+COMMENT          147 166 -- Comment token for "-------------------"
 
-WHITE_SPACE                   151 153
+WHITE_SPACE      166 168
 
-AdaTokenType.COMMENT          153 172 -- Comment token for "-- Function body --"
+COMMENT          168 187 -- Comment token for "-- Function body --"
 
-WHITE_SPACE                   172 174
+WHITE_SPACE      187 189
 
-AdaTokenType.COMMENT          174 193 -- Comment token for "-------------------"
+COMMENT          189 208 -- Comment token for "-------------------"
 
-WHITE_SPACE                   193 194
+WHITE_SPACE      208 210
 
-AdaTokenType.END_KEYWORD      194 197 -- end
-WHITE_SPACE                   197 198
-AdaTokenType.IDENTIFIER       198 202 --     test
-AdaTokenType.SEMICOLON        202 203 --         ;
+RETURN_KEYWORD   210 216 -- return
+WHITE_SPACE      216 217
+DECIMAL_LITERAL  217 219 --        42
+SEMICOLON        219 220 --          ;
 
-WHITE_SPACE                   203 205
+WHITE_SPACE      220 221
 
-AdaTokenType.COMMENT          205 264 -- Comment token for "-- This comment should..."
+END_KEYWORD      221 224 -- end
+WHITE_SPACE      224 225
+IDENTIFIER       225 229 --     test
+SEMICOLON        229 230 --         ;
+
+WHITE_SPACE      230 232
+
+COMMENT          232 291 -- Comment token for "-- This comment should..."

--- a/src/test/resources/ada-sources/delimiters.adb
+++ b/src/test/resources/ada-sources/delimiters.adb
@@ -1,0 +1,14 @@
+-- Single Delimiters
+& ' ( ) * + , - . / : ; < = > |
+
+-- Compound Delimiters
+=> .. ** := /= >= <= << >> <>
+
+-- Special cases
+=>=
+<=>
+<<>
+<<>>
+<>>
+char'a'cter_literal
+apostrophe'delimiter

--- a/src/test/resources/ada-sources/delimiters.adb
+++ b/src/test/resources/ada-sources/delimiters.adb
@@ -10,5 +10,6 @@
 <<>
 <<>>
 <>>
-char'a'cter_literal
+character_literal('a')
 apostrophe'delimiter
+Character'('a')

--- a/src/test/resources/ada-sources/delimiters.adb.token-list
+++ b/src/test/resources/ada-sources/delimiters.adb.token-list
@@ -109,14 +109,23 @@ GREATER_THAN_SIGN   144 145 --   >
 
 WHITE_SPACE         145 146
 
-IDENTIFIER          146 150 -- char
-CHARACTER_LITERAL   150 153 --     'a'
-IDENTIFIER          153 165 --        cter_literal
+IDENTIFIER          146 163 -- character_literal
+LEFT_PARENTHESIS    163 164 --                  (
+CHARACTER_LITERAL   164 167 --                   'a'
+RIGHT_PARENTHESIS   167 168 --                      )
 
-WHITE_SPACE         165 166
+WHITE_SPACE         168 169
 
-IDENTIFIER          166 176 -- apostrophe
-APOSTROPHE          176 177 --           '
-IDENTIFIER          177 186 --            delimiter
+IDENTIFIER          169 179 -- apostrophe
+APOSTROPHE          179 180 --           '
+IDENTIFIER          180 189 --            delimiter
 
-WHITE_SPACE         186 187
+WHITE_SPACE         189 190
+
+IDENTIFIER          190 199 -- Character
+APOSTROPHE          199 200 --          '
+LEFT_PARENTHESIS    200 201 --           (
+CHARACTER_LITERAL   201 204 --            'a'
+RIGHT_PARENTHESIS   204 205 --               )
+
+WHITE_SPACE         205 206

--- a/src/test/resources/ada-sources/delimiters.adb.token-list
+++ b/src/test/resources/ada-sources/delimiters.adb.token-list
@@ -1,0 +1,122 @@
+-- Token list for the "delimiters.adb" source file.
+-- Note that for the sake of conciseness, the source code is
+-- intentionally not a compilable Ada program, as its only purpose
+-- is to test the lexer's token generation for syntactically valid
+-- Ada delimiters.
+
+COMMENT               0  20 -- Comment token for "-- Single Delimiters"
+
+WHITE_SPACE          20  21
+
+-----------------------
+-- Single Delimiters --
+-----------------------
+
+AMPERSAND            21  22 -- &
+WHITE_SPACE          22  23
+APOSTROPHE           23  24 -- '
+WHITE_SPACE          24  25
+LEFT_PARENTHESIS     25  26 -- (
+WHITE_SPACE          26  27
+RIGHT_PARENTHESIS    27  28 -- )
+WHITE_SPACE          28  29
+ASTERISK             29  30 -- *
+WHITE_SPACE          30  31
+PLUS_SIGN            31  32 -- +
+WHITE_SPACE          32  33
+COMMA                33  34 -- ,
+WHITE_SPACE          34  35
+HYPHEN_MINUS         35  36 -- -
+WHITE_SPACE          36  37
+FULL_STOP            37  38 -- .
+WHITE_SPACE          38  39
+SOLIDUS              39  40 -- /
+WHITE_SPACE          40  41
+COLON                41  42 -- :
+WHITE_SPACE          42  43
+SEMICOLON            43  44 -- ;
+WHITE_SPACE          44  45
+LESS_THAN_SIGN       45  46 -- <
+WHITE_SPACE          46  47
+EQUALS_SIGN          47  48 -- =
+WHITE_SPACE          48  49
+GREATER_THAN_SIGN    49  50 -- >
+WHITE_SPACE          50  51
+VERTICAL_LINE        51  52 -- |
+
+WHITE_SPACE          52  54
+
+COMMENT              54  76 -- Comment token for "-- Compound Delimiters"
+
+WHITE_SPACE          76  77
+
+-------------------------
+-- Compound Delimiters --
+-------------------------
+
+ARROW                77  79 -- =>
+WHITE_SPACE          79  80
+DOUBLE_DOT           80  82 -- ..
+WHITE_SPACE          82  83
+DOUBLE_ASTERISK      83  85 -- **
+WHITE_SPACE          85  86
+ASSIGNMENT           86  88 -- :=
+WHITE_SPACE          88  89
+NOT_EQUAL_SIGN       89  91 -- /=
+WHITE_SPACE          91  92
+GREATER_EQUAL_SIGN   92  94 -- >=
+WHITE_SPACE          94  95
+LESS_EQUAL_SIGN      95  97 -- <=
+WHITE_SPACE          97  98
+LEFT_LABEL_BRACKET   98 100 -- <<
+WHITE_SPACE         100 101
+RIGHT_LABEL_BRACKET 101 103 -- >>
+WHITE_SPACE         103 104
+BOX_SIGN            104 106 -- <>
+
+WHITE_SPACE         106 108
+
+COMMENT             108 124 -- Comment token for "-- Special cases"
+
+WHITE_SPACE         124 125
+
+-------------------
+-- Special cases --
+-------------------
+
+ARROW               125 127 -- =>
+EQUALS_SIGN         127 128 --   =
+
+WHITE_SPACE         128 129
+
+LESS_EQUAL_SIGN     129 131 -- <=
+GREATER_THAN_SIGN   131 132 --   >
+
+WHITE_SPACE         132 133
+
+LEFT_LABEL_BRACKET  133 135 -- <<
+GREATER_THAN_SIGN   135 136 --   >
+
+WHITE_SPACE         136 137
+
+LEFT_LABEL_BRACKET  137 139 -- <<
+RIGHT_LABEL_BRACKET 139 141 --   >>
+
+WHITE_SPACE         141 142
+
+BOX_SIGN            142 144 -- <>
+GREATER_THAN_SIGN   144 145 --   >
+
+WHITE_SPACE         145 146
+
+IDENTIFIER          146 150 -- char
+CHARACTER_LITERAL   150 153 --     'a'
+IDENTIFIER          153 165 --        cter_literal
+
+WHITE_SPACE         165 166
+
+IDENTIFIER          166 176 -- apostrophe
+APOSTROPHE          176 177 --           '
+IDENTIFIER          177 186 --            delimiter
+
+WHITE_SPACE         186 187

--- a/src/test/resources/ada-sources/hello-world.adb.token-list
+++ b/src/test/resources/ada-sources/hello-world.adb.token-list
@@ -1,42 +1,42 @@
 -- Token list for the simple "hello-world.adb" Ada program
 -- and its mixed-case version "hello-world-mixed-case.adb".
 
-AdaTokenType.WITH_KEYWORD        0   4 -- with
-WHITE_SPACE                      4   5
-AdaTokenType.IDENTIFIER          5   8 --      Ada
-AdaTokenType.FULL_STOP           8   9 --         .
-AdaTokenType.IDENTIFIER          9  16 --          Text_IO
-AdaTokenType.SEMICOLON          16  17 --                 ;
+WITH_KEYWORD        0   4 -- with
+WHITE_SPACE         4   5
+IDENTIFIER          5   8 --      Ada
+FULL_STOP           8   9 --         .
+IDENTIFIER          9  16 --          Text_IO
+SEMICOLON          16  17 --                 ;
 
-WHITE_SPACE                     17  19
+WHITE_SPACE        17  19
 
-AdaTokenType.PROCEDURE_KEYWORD  19  28 -- procedure
-WHITE_SPACE                     28  29
-AdaTokenType.IDENTIFIER         29  39 --           HelloWorld
-WHITE_SPACE                     39  40
-AdaTokenType.IS_KEYWORD         40  42 --                      is
+PROCEDURE_KEYWORD  19  28 -- procedure
+WHITE_SPACE        28  29
+IDENTIFIER         29  39 --           HelloWorld
+WHITE_SPACE        39  40
+IS_KEYWORD         40  42 --                      is
 
-WHITE_SPACE                     42  43
+WHITE_SPACE        42  43
 
-AdaTokenType.BEGIN_KEYWORD      43  48 -- begin
+BEGIN_KEYWORD      43  48 -- begin
 
-WHITE_SPACE                     48  50
+WHITE_SPACE        48  50
 
-AdaTokenType.IDENTIFIER         50  53 -- Ada
-AdaTokenType.FULL_STOP          53  54 --    .
-AdaTokenType.IDENTIFIER         54  61 --     Text_IO
-AdaTokenType.FULL_STOP          61  62 --            .
-AdaTokenType.IDENTIFIER         62  70 --             Put_Line
-AdaTokenType.LEFT_PARENTHESIS   70  71 --                     (
-AdaTokenType.STRING_LITERAL     71  86 --                      "Hello, World!"
-AdaTokenType.RIGHT_PARENTHESIS  86  87 --                                     )
-AdaTokenType.SEMICOLON          87  88 --                                      ;
+IDENTIFIER         50  53 -- Ada
+FULL_STOP          53  54 --    .
+IDENTIFIER         54  61 --     Text_IO
+FULL_STOP          61  62 --            .
+IDENTIFIER         62  70 --             Put_Line
+LEFT_PARENTHESIS   70  71 --                     (
+STRING_LITERAL     71  86 --                      "Hello, World!"
+RIGHT_PARENTHESIS  86  87 --                                     )
+SEMICOLON          87  88 --                                      ;
 
-WHITE_SPACE                     88  89
+WHITE_SPACE        88  89
 
-AdaTokenType.END_KEYWORD        89  92 -- end
-WHITE_SPACE                     92  93
-AdaTokenType.IDENTIFIER         93 103 --    HelloWorld
-AdaTokenType.SEMICOLON         103 104 --              ;
+END_KEYWORD        89  92 -- end
+WHITE_SPACE        92  93
+IDENTIFIER         93 103 --    HelloWorld
+SEMICOLON         103 104 --              ;
 
-WHITE_SPACE                    104 105
+WHITE_SPACE       104 105

--- a/src/test/resources/ada-sources/keywords.adb
+++ b/src/test/resources/ada-sources/keywords.adb
@@ -1,0 +1,20 @@
+-- Ada Keywords
+abort abs abstract accept access aliased all and array at
+begin body
+case constant
+declare delay delta digits do
+else elsif end entry exception exit
+for function
+generic goto
+if in interface is
+limited loop
+mod
+new not null
+of or others out overriding
+package pragma private procedure protected
+raise range record rem renames requeue return reverse
+select separate some subtype synchronized
+tagged task terminate then type
+until use
+when while with
+xor

--- a/src/test/resources/ada-sources/keywords.adb.token-list
+++ b/src/test/resources/ada-sources/keywords.adb.token-list
@@ -1,0 +1,197 @@
+-- Token list for the "keywords.adb" source file.
+-- Note that for the sake of conciseness, the source code is
+-- intentionally not a compilable Ada program, as its only purpose
+-- is to test the lexer's token generation for syntactically valid
+-- Ada keywords.
+
+COMMENT                0  15 -- Comment token for "-- Ada Keywords"
+
+WHITE_SPACE           15  16
+
+------------------
+-- Ada Keywords --
+------------------
+
+ABORT_KEYWORD         16  21 -- abort
+WHITE_SPACE           21  22
+ABS_KEYWORD           22  25 -- abs
+WHITE_SPACE           25  26
+ABSTRACT_KEYWORD      26  34 -- abstract
+WHITE_SPACE           34  35
+ACCEPT_KEYWORD        35  41 -- accept
+WHITE_SPACE           41  42
+ACCESS_KEYWORD        42  48 -- access
+WHITE_SPACE           48  49
+ALIASED_KEYWORD       49  56 -- aliased
+WHITE_SPACE           56  57
+ALL_KEYWORD           57  60 -- all
+WHITE_SPACE           60  61
+AND_KEYWORD           61  64 -- and
+WHITE_SPACE           64  65
+ARRAY_KEYWORD         65  70 -- array
+WHITE_SPACE           70  71
+AT_KEYWORD            71  73 -- at
+
+WHITE_SPACE           73  74
+
+BEGIN_KEYWORD         74  79 -- begin
+WHITE_SPACE           79  80
+BODY_KEYWORD          80  84 -- body
+
+WHITE_SPACE           84  85
+
+CASE_KEYWORD          85  89 -- case
+WHITE_SPACE           89  90
+CONSTANT_KEYWORD      90  98 -- constant
+
+WHITE_SPACE           98  99
+
+DECLARE_KEYWORD       99 106 -- declare
+WHITE_SPACE          106 107
+DELAY_KEYWORD        107 112 -- delay
+WHITE_SPACE          112 113
+DELTA_KEYWORD        113 118 -- delta
+WHITE_SPACE          118 119
+DIGITS_KEYWORD       119 125 -- digits
+WHITE_SPACE          125 126
+DO_KEYWORD           126 128 -- do
+
+WHITE_SPACE          128 129
+
+ELSE_KEYWORD         129 133 -- else
+WHITE_SPACE          133 134
+ELSIF_KEYWORD        134 139 -- elsif
+WHITE_SPACE          139 140
+END_KEYWORD          140 143 -- end
+WHITE_SPACE          143 144
+ENTRY_KEYWORD        144 149 -- entry
+WHITE_SPACE          149 150
+EXCEPTION_KEYWORD    150 159 -- exception
+WHITE_SPACE          159 160
+EXIT_KEYWORD         160 164 -- exit
+
+WHITE_SPACE          164 165
+
+FOR_KEYWORD          165 168 -- for
+WHITE_SPACE          168 169
+FUNCTION_KEYWORD     169 177 -- function
+
+WHITE_SPACE          177 178
+
+GENERIC_KEYWORD      178 185 -- generic
+WHITE_SPACE          185 186
+GOTO_KEYWORD         186 190 -- goto
+
+WHITE_SPACE          190 191
+
+IF_KEYWORD           191 193 -- if
+WHITE_SPACE          193 194
+IN_KEYWORD           194 196 -- in
+WHITE_SPACE          196 197
+INTERFACE_KEYWORD    197 206 -- interface
+WHITE_SPACE          206 207
+IS_KEYWORD           207 209 -- is
+
+WHITE_SPACE          209 210
+
+LIMITED_KEYWORD      210 217 -- limited
+WHITE_SPACE          217 218
+LOOP_KEYWORD         218 222 -- loop
+
+WHITE_SPACE          222 223
+
+MOD_KEYWORD          223 226 -- mod
+
+WHITE_SPACE          226 227
+
+NEW_KEYWORD          227 230 -- new
+WHITE_SPACE          230 231
+NOT_KEYWORD          231 234 -- not
+WHITE_SPACE          234 235
+NULL_KEYWORD         235 239 -- null
+
+WHITE_SPACE          239 240
+
+OF_KEYWORD           240 242 -- of
+WHITE_SPACE          242 243
+OR_KEYWORD           243 245 -- or
+WHITE_SPACE          245 246
+OTHERS_KEYWORD       246 252 -- others
+WHITE_SPACE          252 253
+OUT_KEYWORD          253 256 -- out
+WHITE_SPACE          256 257
+OVERRIDING_KEYWORD   257 267 -- overriding
+
+WHITE_SPACE          267 268
+
+PACKAGE_KEYWORD      268 275 -- package
+WHITE_SPACE          275 276
+PRAGMA_KEYWORD       276 282 -- pragma
+WHITE_SPACE          282 283
+PRIVATE_KEYWORD      283 290 -- private
+WHITE_SPACE          290 291
+PROCEDURE_KEYWORD    291 300 -- procedure
+WHITE_SPACE          300 301
+PROTECTED_KEYWORD    301 310 -- protected
+
+WHITE_SPACE          310 311
+
+RAISE_KEYWORD        311 316 -- raise
+WHITE_SPACE          316 317
+RANGE_KEYWORD        317 322 -- range
+WHITE_SPACE          322 323
+RECORD_KEYWORD       323 329 -- record
+WHITE_SPACE          329 330
+REM_KEYWORD          330 333 -- rem
+WHITE_SPACE          333 334
+RENAMES_KEYWORD      334 341 -- renames
+WHITE_SPACE          341 342
+REQUEUE_KEYWORD      342 349 -- requeue
+WHITE_SPACE          349 350
+RETURN_KEYWORD       350 356 -- return
+WHITE_SPACE          356 357
+REVERSE_KEYWORD      357 364 -- reverse
+
+WHITE_SPACE          364 365
+
+SELECT_KEYWORD       365 371 -- select
+WHITE_SPACE          371 372
+SEPARATE_KEYWORD     372 380 -- separate
+WHITE_SPACE          380 381
+SOME_KEYWORD         381 385 -- some
+WHITE_SPACE          385 386
+SUBTYPE_KEYWORD      386 393 -- subtype
+WHITE_SPACE          393 394
+SYNCHRONIZED_KEYWORD 394 406 -- synchronized
+
+WHITE_SPACE          406 407
+
+TAGGED_KEYWORD       407 413 -- tagged
+WHITE_SPACE          413 414
+TASK_KEYWORD         414 418 -- task
+WHITE_SPACE          418 419
+TERMINATE_KEYWORD    419 428 -- terminate
+WHITE_SPACE          428 429
+THEN_KEYWORD         429 433 -- then
+WHITE_SPACE          433 434
+TYPE_KEYWORD         434 438 -- type
+
+WHITE_SPACE          438 439
+
+UNTIL_KEYWORD        439 444 -- until
+WHITE_SPACE          444 445
+USE_KEYWORD          445 448 -- use
+
+WHITE_SPACE          448 449
+
+WHEN_KEYWORD         449 453 -- when
+WHITE_SPACE          453 454
+WHILE_KEYWORD        454 459 -- while
+WHITE_SPACE          459 460
+WITH_KEYWORD         460 464 -- with
+
+WHITE_SPACE          464 465
+
+XOR_KEYWORD          465 468 -- xor
+
+WHITE_SPACE          468 469

--- a/src/test/resources/ada-sources/literals.adb
+++ b/src/test/resources/ada-sources/literals.adb
@@ -34,5 +34,5 @@
 "Hello world!"
 "A single quote ' in a string literal"
 "The following is not a comment -- hello world!"
-"This is a""single valid string""literal in Ada"
+"This is a ""single valid string literal"" in Ada"
 "But these are separate" "string literals in Ada"

--- a/src/test/resources/ada-sources/literals.adb.token-list
+++ b/src/test/resources/ada-sources/literals.adb.token-list
@@ -4,160 +4,160 @@
 -- is to test the lexer's token generation for syntactically valid
 -- Ada literals.
 
-AdaTokenType.COMMENT             0  19 -- Comment token for "-- Numeric Literals"
+COMMENT             0  19 -- Comment token for "-- Numeric Literals"
 
-WHITE_SPACE                     19  20
+WHITE_SPACE        19  20
 
 ----------------------
 -- Numeric Literals --
 ----------------------
 
-AdaTokenType.DECIMAL_LITERAL    20  23 -- 123
+DECIMAL_LITERAL    20  23 -- 123
 
-WHITE_SPACE                     23  24
+WHITE_SPACE        23  24
 
-AdaTokenType.DECIMAL_LITERAL    24  31 -- 123_456
+DECIMAL_LITERAL    24  31 -- 123_456
 
-WHITE_SPACE                     31  32
+WHITE_SPACE        31  32
 
-AdaTokenType.DECIMAL_LITERAL    32  40 -- 12_34_56
+DECIMAL_LITERAL    32  40 -- 12_34_56
 
-WHITE_SPACE                     40  41
+WHITE_SPACE        40  41
 
-AdaTokenType.DECIMAL_LITERAL    41  48 -- 123.456
+DECIMAL_LITERAL    41  48 -- 123.456
 
-WHITE_SPACE                     48  49
+WHITE_SPACE        48  49
 
-AdaTokenType.DECIMAL_LITERAL    49  60 -- 123_456.789
+DECIMAL_LITERAL    49  60 -- 123_456.789
 
-WHITE_SPACE                     60  61
+WHITE_SPACE        60  61
 
-AdaTokenType.DECIMAL_LITERAL    61  72 -- 123.456_789
+DECIMAL_LITERAL    61  72 -- 123.456_789
 
-WHITE_SPACE                     72  73
+WHITE_SPACE        72  73
 
-AdaTokenType.DECIMAL_LITERAL    73  85 -- 12_34.567_89
+DECIMAL_LITERAL    73  85 -- 12_34.567_89
 
-WHITE_SPACE                     85  86
+WHITE_SPACE        85  86
 
-AdaTokenType.DECIMAL_LITERAL    86  92 -- 123E12
+DECIMAL_LITERAL    86  92 -- 123E12
 
-WHITE_SPACE                     92  93
+WHITE_SPACE        92  93
 
-AdaTokenType.DECIMAL_LITERAL    93 101 -- 1.23e5_4
+DECIMAL_LITERAL    93 101 -- 1.23e5_4
 
-WHITE_SPACE                    101 102
+WHITE_SPACE       101 102
 
-AdaTokenType.DECIMAL_LITERAL   102 109 -- 12_3E+5
+DECIMAL_LITERAL   102 109 -- 12_3E+5
 
-WHITE_SPACE                    109 110
+WHITE_SPACE       109 110
 
-AdaTokenType.DECIMAL_LITERAL   110 118 -- 1.2_3e+5
+DECIMAL_LITERAL   110 118 -- 1.2_3e+5
 
-WHITE_SPACE                    118 119
+WHITE_SPACE       118 119
 
-AdaTokenType.DECIMAL_LITERAL   119 127 -- 1_2.3E-5
+DECIMAL_LITERAL   119 127 -- 1_2.3E-5
 
-WHITE_SPACE                    127 128
+WHITE_SPACE       127 128
 
-AdaTokenType.DECIMAL_LITERAL   128 136 -- 123.4e-5
+DECIMAL_LITERAL   128 136 -- 123.4e-5
 
-WHITE_SPACE                    136 137
+WHITE_SPACE       136 137
 
-AdaTokenType.BASED_LITERAL     137 143 -- 1#123#
+BASED_LITERAL     137 143 -- 1#123#
 
-WHITE_SPACE                    143 144
+WHITE_SPACE       143 144
 
-AdaTokenType.BASED_LITERAL     144 158 -- 1_6#123.3#e-12
+BASED_LITERAL     144 158 -- 1_6#123.3#e-12
 
-WHITE_SPACE                    158 159
+WHITE_SPACE       158 159
 
-AdaTokenType.BASED_LITERAL     159 174 -- 32#12_3_Ab#E4_5
+BASED_LITERAL     159 174 -- 32#12_3_Ab#E4_5
 
-WHITE_SPACE                    174 176
+WHITE_SPACE       174 176
 
-AdaTokenType.COMMENT           176 195 -- Comment token for "-- Textual Literals"
+COMMENT           176 195 -- Comment token for "-- Textual Literals"
 
-WHITE_SPACE                    195 196
+WHITE_SPACE       195 196
 
 ----------------------
 -- Textual Literals --
 ----------------------
 
-AdaTokenType.CHARACTER_LITERAL 196 199 -- ' '
+CHARACTER_LITERAL 196 199 -- ' '
 
-WHITE_SPACE                    199 200
+WHITE_SPACE       199 200
 
-AdaTokenType.CHARACTER_LITERAL 200 203 -- 'A'
+CHARACTER_LITERAL 200 203 -- 'A'
 
-WHITE_SPACE                    203 204
+WHITE_SPACE       203 204
 
-AdaTokenType.CHARACTER_LITERAL 204 207 -- 'b'
+CHARACTER_LITERAL 204 207 -- 'b'
 
-WHITE_SPACE                    207 208
+WHITE_SPACE       207 208
 
-AdaTokenType.CHARACTER_LITERAL 208 211 -- '0'
+CHARACTER_LITERAL 208 211 -- '0'
 
-WHITE_SPACE                    211 212
+WHITE_SPACE       211 212
 
-AdaTokenType.CHARACTER_LITERAL 212 215 -- ';'
+CHARACTER_LITERAL 212 215 -- ';'
 
-WHITE_SPACE                    215 216
+WHITE_SPACE       215 216
 
-AdaTokenType.CHARACTER_LITERAL 216 219 -- '"'
+CHARACTER_LITERAL 216 219 -- '"'
 
-WHITE_SPACE                    219 220
+WHITE_SPACE       219 220
 
-AdaTokenType.CHARACTER_LITERAL 220 223 -- '['
+CHARACTER_LITERAL 220 223 -- '['
 
-WHITE_SPACE                    223 224
+WHITE_SPACE       223 224
 
-AdaTokenType.CHARACTER_LITERAL 224 227 -- '}'
+CHARACTER_LITERAL 224 227 -- '}'
 
-WHITE_SPACE                    227 228
+WHITE_SPACE       227 228
 
-AdaTokenType.CHARACTER_LITERAL 228 231 -- '#'
+CHARACTER_LITERAL 228 231 -- '#'
 
-WHITE_SPACE                    231 232
+WHITE_SPACE       231 232
 
-AdaTokenType.CHARACTER_LITERAL 232 235 -- '='
+CHARACTER_LITERAL 232 235 -- '='
 
-WHITE_SPACE                    235 236
+WHITE_SPACE       235 236
 
-AdaTokenType.CHARACTER_LITERAL 236 239 -- '+'
+CHARACTER_LITERAL 236 239 -- '+'
 
-WHITE_SPACE                    239 240
+WHITE_SPACE       239 240
 
-AdaTokenType.CHARACTER_LITERAL 240 243 -- '/'
+CHARACTER_LITERAL 240 243 -- '/'
 
-WHITE_SPACE                    243 244
+WHITE_SPACE       243 244
 
-AdaTokenType.CHARACTER_LITERAL 244 247 -- '?'
+CHARACTER_LITERAL 244 247 -- '?'
 
-WHITE_SPACE                    247 248
+WHITE_SPACE       247 248
 
-AdaTokenType.STRING_LITERAL    248 255 -- "Hello"
+STRING_LITERAL    248 255 -- "Hello"
 
-WHITE_SPACE                    255 256
+WHITE_SPACE       255 256
 
-AdaTokenType.STRING_LITERAL    256 270 -- "Hello world!"
+STRING_LITERAL    256 270 -- "Hello world!"
 
-WHITE_SPACE                    270 271
+WHITE_SPACE       270 271
 
-AdaTokenType.STRING_LITERAL    271 309 -- "A single quote..."
+STRING_LITERAL    271 309 -- "A single quote..."
 
-WHITE_SPACE                    309 310
+WHITE_SPACE       309 310
 
-AdaTokenType.STRING_LITERAL    310 358 -- "The following is..."
+STRING_LITERAL    310 358 -- "The following is..."
 
-WHITE_SPACE                    358 359
+WHITE_SPACE       358 359
 
-AdaTokenType.STRING_LITERAL    359 407 -- "This is a"" single..."
+STRING_LITERAL    359 409 -- "This is a ""single..."
 
-WHITE_SPACE                    407 408
+WHITE_SPACE       409 410
 
-AdaTokenType.STRING_LITERAL    408 432 -- "But these are separate"
-WHITE_SPACE                    432 433
-AdaTokenType.STRING_LITERAL    433 457 --                          "string literals in Ada"
+STRING_LITERAL    410 434 -- "But these are separate"
+WHITE_SPACE       434 435
+STRING_LITERAL    435 459 --                          "string literals in Ada"
 
-WHITE_SPACE                    457 458
+WHITE_SPACE       459 460


### PR DESCRIPTION
This PR mainly fixes a bug in the lexer's matching logic. A typical example of Ada code that was incorrectly lexed because of this bug is `MyInteger'Image` in which case the lexer used to break the code into the following token sequence
```
    MyInteger'Image
    \_______/\/\__/
        /     |  \
IDENTIFIER    |  IDENTIFIER
       BAD_CHARACTER
```
instead of the following token sequence
```
    MyInteger'Image
    \_______/|\___/
        /    |   \
IDENTIFIER   |   IDENTIFIER
         APOSTROPHE
```
Other changes in this PR:
- Added convenience methods to AdaLexer
- Defined token sets in AdaTokenTypes
- Additional test cases
- Renamed `OORegex` and `ConcatRegex` and corresponding test classes (which resulted in a lot of changes in the code, sorry :p)
- Minor refactorings + clean-ups