### PR TITLE
Enabled caching targets of Ada PSI references

### DIFF
--- a/src/main/control/com/adacore/adaintellij/Utils.java
+++ b/src/main/control/com/adacore/adaintellij/Utils.java
@@ -246,6 +246,46 @@ public final class Utils {
 	}
 	
 	/**
+	 * Returns whether or not the given PSI files represent the
+	 * same underlying file.
+	 *
+	 * @param file1 The first PSI file to test.
+	 * @param file2 The second PSI file to test.
+	 * @return Whether or not the given PSI files are equivalent.
+	 */
+	public static boolean psiFilesRepresentSameFile(
+		@NotNull PsiFile file1,
+		@NotNull PsiFile file2
+	) {
+		
+		VirtualFile virtualFile1 = getPsiFileVirtualFile(file1);
+		
+		return virtualFile1 != null &&
+			virtualFile1.equals(getPsiFileVirtualFile(file2));
+		
+	}
+	
+	/**
+	 * Returns whether or not the given documents represent the
+	 * same underlying file.
+	 *
+	 * @param document1 The first document to test.
+	 * @param document2 The second document to test.
+	 * @return Whether or not the given documents are equivalent.
+	 */
+	public static boolean documentsRepresentSameFile(
+		@NotNull Document document1,
+		@NotNull Document document2
+	) {
+		
+		VirtualFile virtualFile1 = getDocumentVirtualFile(document1);
+		
+		return virtualFile1 != null &&
+			virtualFile1.equals(getDocumentVirtualFile(document2));
+		
+	}
+	
+	/**
 	 * Returns the text content of the given file as a string, or
 	 * null if the given file is in binary format.
 	 *

--- a/src/main/control/com/adacore/adaintellij/analysis/semantic/AdaParser.java
+++ b/src/main/control/com/adacore/adaintellij/analysis/semantic/AdaParser.java
@@ -53,8 +53,8 @@ import org.jetbrains.annotations.NotNull;
  *                        SEMICOLON    -------   AdaPsiElement---|
  *                           ...       -------             ...---|
  *
- * As this example demonstrates, the final abstract trees returned y this parser
- * are not ASTs in the proper, traditional sense of the word, namely:
+ * As this example demonstrates, the final abstract trees returned by this
+ * parser are not ASTs in the proper, traditional sense of the word, namely:
  *  - They maintain ALL elements of the source code, including whitespaces,
  *    comments, delimiters, etc.
  *  - They have absolutely no semantic dimension to them

--- a/src/main/control/com/adacore/adaintellij/analysis/semantic/AdaPsiElement.java
+++ b/src/main/control/com/adacore/adaintellij/analysis/semantic/AdaPsiElement.java
@@ -9,6 +9,7 @@ import com.intellij.util.IncorrectOperationException;
 import org.jetbrains.annotations.*;
 
 import com.adacore.adaintellij.Icons;
+import com.adacore.adaintellij.Utils;
 
 /**
  * Ada AST node that is not a root node.
@@ -307,8 +308,8 @@ public class AdaPsiElement extends LeafPsiElement implements NavigatablePsiEleme
 	 * @return Whether or not the given elements are in the same file.
 	 */
 	public static boolean areInSameFile(@NotNull PsiElement element1, @NotNull PsiElement element2) {
-		return element1.getContainingFile().getVirtualFile()
-			.equals(element2.getContainingFile().getVirtualFile());
+		return Utils.psiFilesRepresentSameFile(
+			element1.getContainingFile(), element2.getContainingFile());
 	}
 	
 	/**


### PR DESCRIPTION
IntelliJ IDEA seems to make a lot of repetitive calls to `PsiReference#resolve()` which resulted in a lot of unnecessary requests to the server. This PR enables caching reference targets so they can be read directly from cache as long as the PSI tree does not change.