### PR TITLE
Merging LSP change updates for better performance + minor fixes

### DIFF
--- a/src/main/control/com/adacore/adaintellij/editor/AdaDocumentListener.java
+++ b/src/main/control/com/adacore/adaintellij/editor/AdaDocumentListener.java
@@ -1,0 +1,78 @@
+package com.adacore.adaintellij.editor;
+
+import com.intellij.openapi.editor.event.*;
+import com.intellij.openapi.vfs.VirtualFile;
+import org.jetbrains.annotations.*;
+
+import com.adacore.adaintellij.file.AdaFileType;
+import com.adacore.adaintellij.Utils;
+
+/**
+ * Document listener for Ada source file documents.
+ * Listeners of this class will discard events originating from
+ * documents that do not correspond to Ada source files, as well as
+ * events corresponding to internal document manoeuvres performed by
+ * the IntelliJ platform to provide certain features.
+ * An example of such manoeuvres is the temporary insertion of dummy
+ * text (e.g. "IntellijIdeaRulezzz") in a document corresponding to
+ * an in-memory copy of the active document's virtual file during
+ * code completion or renaming.
+ */
+public class AdaDocumentListener implements DocumentListener {
+	
+	/**
+	 * @see com.intellij.openapi.editor.event.DocumentListener#beforeDocumentChange(DocumentEvent)
+	 */
+	@Override
+	public final void beforeDocumentChange(DocumentEvent event) {
+		
+		if (!shouldHandleEvent(event)) { return; }
+		
+		beforeAdaDocumentChanged(event);
+		
+	}
+	
+	/**
+	 * @see com.intellij.openapi.editor.event.DocumentListener#documentChanged(DocumentEvent)
+	 */
+	@Override
+	public final void documentChanged(DocumentEvent event) {
+		
+		if (!shouldHandleEvent(event)) { return; }
+		
+		adaDocumentChanged(event);
+		
+	}
+	
+	/**
+	 * Returns whether or not the given document event should be
+	 * handled.
+	 *
+	 * @param event The document event to test.
+	 * @return Whether or not the given event should be handled.
+	 */
+	private boolean shouldHandleEvent(@Nullable DocumentEvent event) {
+		
+		if (event == null) { return false; }
+		
+		VirtualFile file = Utils.getDocumentVirtualFile(event.getDocument());
+		
+		return file != null &&
+			file.isInLocalFileSystem() &&
+			AdaFileType.isAdaFile(file);
+		
+	}
+	
+	/**
+	 * Variant of `beforeDocumentChanged` for Ada documents:
+	 * @see com.intellij.openapi.editor.event.DocumentListener#beforeDocumentChange(DocumentEvent)
+	 */
+	public void beforeAdaDocumentChanged(@NotNull DocumentEvent event) {}
+	
+	/**
+	 * Variant of `documentChanged` for Ada documents:
+	 * @see com.intellij.openapi.editor.event.DocumentListener#documentChanged(DocumentEvent)
+	 */
+	public void adaDocumentChanged(@NotNull DocumentEvent event) {}
+	
+}

--- a/src/main/control/com/adacore/adaintellij/editor/BusyEditorAwareOperation.java
+++ b/src/main/control/com/adacore/adaintellij/editor/BusyEditorAwareOperation.java
@@ -1,0 +1,101 @@
+package com.adacore.adaintellij.editor;
+
+import com.intellij.openapi.util.Disposer;
+import com.intellij.util.ui.update.MergingUpdateQueue;
+import org.jetbrains.annotations.*;
+
+/**
+ * Generic operation that can be scheduled to execute repeatedly.
+ * @see com.adacore.adaintellij.editor.BusyEditorAwareScheduler
+ *
+ * Different implementations have different scheduling mechanisms,
+ * which is why this class does not provide a scheduling interface
+ * and instead leaves it to the implementations to do so.
+ */
+abstract class BusyEditorAwareOperation {
+	
+	/**
+	 * Internal merging queue holding scheduled executions.
+	 */
+	MergingUpdateQueue queue;
+	
+	/**
+	 * The scheduler responsible for this operation.
+	 */
+	private BusyEditorAwareScheduler scheduler;
+	
+	/**
+	 * Whether or not this operation is active.
+	 */
+	private boolean active = true;
+	
+	/**
+	 * Constructs a new BusyEditorAwareOperation given a scheduler.
+	 *
+	 * @param scheduler The scheduler responsible for the created
+	 *                  operation.
+	 */
+	BusyEditorAwareOperation(@NotNull BusyEditorAwareScheduler scheduler) {
+		this(scheduler, BusyEditorAwareScheduler.DEFAULT_TIMEOUT);
+	}
+	
+	/**
+	 * Constructs a new BusyEditorAwareOperation given a scheduler
+	 * and a merge timeout.
+	 *
+	 * @param scheduler The scheduler responsible for the created
+	 *                  operation.
+	 * @param timeout The merge timeout of the created operation.
+	 */
+	BusyEditorAwareOperation(@NotNull BusyEditorAwareScheduler scheduler, int timeout) {
+		this.scheduler = scheduler;
+		this.queue     = new MergingUpdateQueue(
+			"BusyEditorAwareOperation@" + hashCode(), timeout, true, null);
+	}
+	
+	/**
+	 * Stops this operation from executing in the future.
+	 */
+	public final void stop() {
+		
+		// If this operation has already been stopped,
+		// then return immediately
+		
+		if (!active) { return; }
+		
+		// Deactivate this operation
+		
+		active = false;
+		
+		// Call the extensible clean-up method
+		
+		cleanUp();
+		
+		// Perform global clean-up
+		
+		queue.deactivate();
+		Disposer.dispose(queue);
+		
+		// Remove this operation from the scheduler
+		
+		scheduler.removeOperation(this);
+		
+	}
+	
+	/**
+	 * Returns whether or not this operation is active.
+	 *
+	 * @return Whether or not this operation is active.
+	 */
+	@Contract(pure = true)
+	public final boolean isActive() { return active; }
+	
+	/**
+	 * Performs additional clean-up.
+	 * This method is meant to be overridden by concrete operation
+	 * implementations that require custom additional clean-up.
+	 * The default implementation performs no clean-up.
+	 */
+	void cleanUp() {}
+	
+}

--- a/src/main/control/com/adacore/adaintellij/editor/BusyEditorAwareScheduler.java
+++ b/src/main/control/com/adacore/adaintellij/editor/BusyEditorAwareScheduler.java
@@ -1,0 +1,218 @@
+package com.adacore.adaintellij.editor;
+
+import java.util.*;
+import java.util.function.Consumer;
+
+import com.intellij.openapi.components.ProjectComponent;
+import com.intellij.openapi.editor.EditorFactory;
+import com.intellij.openapi.editor.event.*;
+import com.intellij.openapi.fileEditor.*;
+import com.intellij.openapi.project.Project;
+import com.intellij.util.messages.MessageBus;
+import org.jetbrains.annotations.*;
+
+/**
+ * Project component acting as an operation scheduler that is aware of
+ * the editor state.
+ * The scheduler works with instances of `BusyEditorAwareOperation` which
+ * represents an operation that can be executed repeatedly.
+ * To improve speed and responsiveness, the scheduler continuously merges
+ * incoming scheduled executions of a given operation into a single
+ * execution and keeps postponing that execution until the editor is idle
+ * for a configurable duration of time.
+ *
+ * @see com.intellij.util.ui.update.MergingUpdateQueue
+ */
+public final class BusyEditorAwareScheduler implements ProjectComponent {
+	
+	/**
+	 * The default operation merge timeout.
+	 */
+	final static int DEFAULT_TIMEOUT = 800;
+	
+	/**
+	 * The set of currently active operations.
+	 */
+	private Set<BusyEditorAwareOperation> operations = new HashSet<>();
+	
+	/**
+	 * Editor event multi-caster.
+	 */
+	private static final EditorEventMulticaster EVENT_MULTICASTER =
+		EditorFactory.getInstance().getEventMulticaster();
+	
+	/**
+	 * The project to which this component belongs.
+	 */
+	private Project project;
+	
+	/**
+	 * Constructs a new BusyEditorAwareScheduler given a project.
+	 *
+	 * @param project The project to attach to the constructed scheduler.
+	 */
+	public BusyEditorAwareScheduler(@NotNull Project project) {
+		this.project = project;
+	}
+	
+	/**
+	 * @see com.intellij.openapi.components.NamedComponent#getComponentName()
+	 */
+	@NotNull
+	@Override
+	public String getComponentName() {
+		return "com.adacore.adaintellij.editor.BusyEditorAwareScheduler";
+	}
+	
+	/**
+	 * @see com.intellij.openapi.components.ProjectComponent#projectOpened()
+	 */
+	@Override
+	public void projectOpened() {
+		
+		// Register document-focus change listener
+		
+		MessageBus messageBus = project.getMessageBus();
+		
+		FileEditorManagerListener listener = new FileEditorManagerListener() {
+			
+			@Override
+			public void selectionChanged(@NotNull FileEditorManagerEvent event) {
+				operations.forEach(operation -> operation.queue.flush());
+			}
+			
+		};
+		
+		messageBus.connect().subscribe(FileEditorManagerListener.FILE_EDITOR_MANAGER, listener);
+		
+		// Register document change listener
+		
+		EVENT_MULTICASTER.addDocumentListener(new AdaDocumentListener() {
+			
+			@Override
+			public void adaDocumentChanged(@NotNull DocumentEvent event) {
+				operations.forEach(operation -> operation.queue.restartTimer());
+			}
+			
+		});
+		
+	}
+	
+	/**
+	 * Returns the BusyEditorAwareScheduler project component of the
+	 * given project.
+	 *
+	 * @param project The project for which to get the component.
+	 * @return The project component.
+	 */
+	@NotNull
+	public static BusyEditorAwareScheduler getInstance(@NotNull Project project) {
+		return project.getComponent(BusyEditorAwareScheduler.class);
+	}
+	
+	/**
+	 * Creates and returns a new `RunnableOperation` with the given
+	 * runnable.
+	 * @see com.adacore.adaintellij.editor.RunnableOperation
+	 *
+	 * @param runnable The runnable to run when the created operation
+	 *                 is executed.
+	 * @return a new `RunnableOperation` based on the given runnable.
+	 */
+	@Contract("_ -> new")
+	@NotNull
+	public RunnableOperation createRunnableOperation(@NotNull Runnable runnable) {
+		return addAndReturn(new RunnableOperation(this, runnable));
+	}
+	
+	/**
+	 * Creates and returns a new `RunnableOperation` with the given
+	 * runnable and merge timeout.
+	 * @see com.adacore.adaintellij.editor.RunnableOperation
+	 *
+	 * @param runnable The runnable to run when the created operation
+	 *                 is executed.
+	 * @param timeout The merge timeout of the created operation.
+	 * @return a new `RunnableOperation` based on the given runnable.
+	 */
+	@Contract("_, _ -> new")
+	@NotNull
+	public RunnableOperation createRunnableOperation(@NotNull Runnable runnable, int timeout) {
+		return addAndReturn(new RunnableOperation(this, timeout, runnable));
+	}
+	
+	/**
+	 * Creates and returns a new `ConsumerOperation` with the given
+	 * consumer.
+	 * @see com.adacore.adaintellij.editor.ConsumerOperation
+	 *
+	 * @param consumer The consumer to run when the created operation
+	 *                 is executed.
+	 * @param <T> The value type of the created `ConsumerOperation`.
+	 * @return a new `ConsumerOperation` based on the given consumer.
+	 */
+	@Contract("_ -> new")
+	@NotNull
+	public <T> ConsumerOperation<T> createConsumerOperation(
+		@NotNull Consumer<List<T>> consumer
+	) { return addAndReturn(new ConsumerOperation<>(this, consumer)); }
+	
+	/**
+	 * Creates and returns a new `ConsumerOperation` with the given
+	 * consumer and merge timeout.
+	 * @see com.adacore.adaintellij.editor.ConsumerOperation
+	 *
+	 * @param consumer The consumer to run when the created operation
+	 *                 is executed.
+	 * @param timeout The merge timeout of the created operation.
+	 * @param <T> The value type of the created `ConsumerOperation`.
+	 * @return a new `ConsumerOperation` based on the given consumer.
+	 */
+	@Contract("_, _ -> new")
+	@NotNull
+	public <T> ConsumerOperation<T> createConsumerOperation(
+		@NotNull Consumer<List<T>> consumer,
+		         int               timeout
+	) { return addAndReturn(new ConsumerOperation<>(this, timeout, consumer)); }
+	
+	/**
+	 * Creates and returns a new `DocumentChangeConsumerOperation`
+	 * with the given consumer.
+	 * @see DocumentChangeConsumerOperation
+	 *
+	 * @param consumer The consumer to run when the created operation
+	 *                 is executed.
+	 * @return a new `DocumentChangeConsumerOperation` based on the
+	 *         given consumer.
+	 */
+	@Contract("_ -> new")
+	@NotNull
+	public DocumentChangeConsumerOperation createDocumentChangeOperation(
+		@NotNull Consumer<List<DocumentEvent>> consumer
+	) { return addAndReturn(new DocumentChangeConsumerOperation(this, consumer)); }
+	
+	void removeOperation(
+		@NotNull BusyEditorAwareOperation operation
+	) { operations.remove(operation); }
+	
+	/**
+	 * Returns the given operation after adding it to the set of
+	 * currently active operations.
+	 *
+	 * @param operation The operation to add.
+	 * @param <OperationType> The type of operation to add.
+	 * @return The given operation.
+	 */
+	@Contract("_ -> param1")
+	@NotNull
+	private <OperationType extends BusyEditorAwareOperation>
+		OperationType addAndReturn(@NotNull OperationType operation)
+	{
+		
+		operations.add(operation);
+		
+		return operation;
+		
+	}
+	
+}

--- a/src/main/control/com/adacore/adaintellij/editor/ConsumerOperation.java
+++ b/src/main/control/com/adacore/adaintellij/editor/ConsumerOperation.java
@@ -1,0 +1,104 @@
+package com.adacore.adaintellij.editor;
+
+import java.util.*;
+import java.util.function.Consumer;
+
+import com.intellij.util.ui.update.Update;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Consumer busy-editor-aware operation.
+ * Merging executions of such operations will result in execution
+ * values being aggregated and fed together to the consumer once
+ * the underlying queue times out and the operation executes.
+ * @see com.adacore.adaintellij.editor.BusyEditorAwareOperation
+ *
+ * For an example use case of a consumer operation:
+ * @see DocumentChangeConsumerOperation
+ */
+public class ConsumerOperation<T> extends BusyEditorAwareOperation {
+	
+	/**
+	 * The underlying consumer that is run when this operation
+	 * is executed.
+	 */
+	Consumer<List<T>> consumer;
+	
+	/**
+	 * The list of scheduled execution values to be consumed.
+	 */
+	List<T> scheduledValues = new ArrayList<>();
+	
+	/**
+	 * Constructs a new ConsumerOperation given a scheduler and
+	 * a consumer.
+	 *
+	 * @param scheduler The scheduler responsible for the created
+	 *                  operation.
+	 * @param consumer The consumer to run when the created
+	 *                 operation is executed.
+	 */
+	ConsumerOperation(
+		@NotNull BusyEditorAwareScheduler scheduler,
+		@NotNull Consumer<List<T>>        consumer
+	) {
+		super(scheduler);
+		this.consumer = consumer;
+	}
+	
+	/**
+	 * Constructs a new ConsumerOperation given a scheduler, a
+	 * merge timeout and a consumer.
+	 *
+	 * @param scheduler The scheduler responsible for the created
+	 *                  operation.
+	 * @param timeout The merge timeout of the created operation.
+	 * @param consumer The consumer to run when the created
+	 *                 operation is executed.
+	 */
+	ConsumerOperation(
+		@NotNull BusyEditorAwareScheduler scheduler,
+		         int                      timeout,
+		@NotNull Consumer<List<T>>        consumer
+	) {
+		super(scheduler, timeout);
+		this.consumer = consumer;
+	}
+	
+	/**
+	 * Schedules an execution of this consumer operation, with
+	 * the given value.
+	 *
+	 * @param value The value to be consumed.
+	 */
+	public void schedule(@NotNull T value) {
+		
+		// If this operation is not active, then return
+		
+		if (!isActive()) { return; }
+		
+		boolean empty = scheduledValues.isEmpty();
+		
+		// Add the value to the list of values to be consumed
+		
+		scheduledValues.add(value);
+		
+		// If the list was empty, then schedule an execution
+		// in the internal queue
+		
+		if (empty) {
+			
+			queue.queue(Update.create(this, () -> {
+				
+				consumer.accept(scheduledValues);
+				
+				scheduledValues.clear();
+				
+			}));
+			
+		}
+		
+		
+	}
+	
+}

--- a/src/main/control/com/adacore/adaintellij/editor/DocumentChangeConsumerOperation.java
+++ b/src/main/control/com/adacore/adaintellij/editor/DocumentChangeConsumerOperation.java
@@ -1,0 +1,106 @@
+package com.adacore.adaintellij.editor;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+import com.intellij.openapi.editor.EditorFactory;
+import com.intellij.openapi.editor.event.*;
+import org.jetbrains.annotations.NotNull;
+
+import com.adacore.adaintellij.Utils;
+
+/**
+ * Document aggregate change consumer operation.
+ * Operations of this type are not tied to a particular document, they
+ * register document listener in editor event multi-casters in order to
+ * schedule executions on events from any document.
+ * When an event occurs for a different document, the underlying
+ * merging queue is flushed, immediately executing scheduled executions
+ * for the previous document, before the incoming event is processed.
+ */
+public final class DocumentChangeConsumerOperation
+	extends ConsumerOperation<DocumentEvent>
+{
+	
+	/**
+	 * Editor event multi-caster.
+	 */
+	private static final EditorEventMulticaster EVENT_MULTICASTER =
+		EditorFactory.getInstance().getEventMulticaster();
+	
+	/**
+	 * Document change listener for scheduling operation executions
+	 * on document changes.
+	 */
+	private DocumentListener documentListener = new AdaDocumentListener() {
+		
+		/**
+		 * @see com.adacore.adaintellij.editor.AdaDocumentListener#adaDocumentChanged(DocumentEvent)
+		 */
+		@Override
+		public void adaDocumentChanged(@NotNull DocumentEvent event) {
+			schedule(event);
+		}
+		
+	};
+	
+	/**
+	 * Constructs a new DocumentChangeConsumerOperation given a
+	 * scheduler and a consumer.
+	 * @param scheduler The scheduler responsible for the created
+	 *                  operation.
+	 * @param consumer The consumer to run when the created operation
+	 *                 is executed.
+	 */
+	DocumentChangeConsumerOperation(
+		@NotNull BusyEditorAwareScheduler      scheduler,
+		@NotNull Consumer<List<DocumentEvent>> consumer
+	) {
+		
+		super(scheduler, consumer);
+		
+		EVENT_MULTICASTER.addDocumentListener(documentListener);
+		
+	}
+	
+	/**
+	 * Schedules an execution of this document event consumer operation
+	 * with the given document event.
+	 * This method is typically only called from the document listener
+	 * owned by this class.
+	 *
+	 * @param event The document event to be consumed.
+	 */
+	@Override
+	public void schedule(@NotNull DocumentEvent event) {
+		
+		// If this operation is not active, then return
+		
+		if (!isActive()) { return; }
+		
+		// If the event document is different than that of the
+		// events currently scheduled to be consumed, then flush
+		// the internal merging queue and clear the event list
+		
+		if (!scheduledValues.isEmpty() && !Utils.documentsRepresentSameFile(
+			scheduledValues.get(0).getDocument(), event.getDocument()))
+		{
+			queue.flush();
+			scheduledValues.clear();
+		}
+		
+		// Schedule an execution with the event
+		
+		super.schedule(event);
+		
+	}
+	
+	/**
+	 * @see com.adacore.adaintellij.editor.BusyEditorAwareOperation#cleanUp()
+	 */
+	@Override
+	void cleanUp() {
+		EVENT_MULTICASTER.removeDocumentListener(documentListener);
+	}
+	
+}

--- a/src/main/control/com/adacore/adaintellij/editor/RunnableOperation.java
+++ b/src/main/control/com/adacore/adaintellij/editor/RunnableOperation.java
@@ -1,0 +1,68 @@
+package com.adacore.adaintellij.editor;
+
+import com.intellij.util.ui.update.Update;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Simple runnable busy-editor-aware operation.
+ * @see com.adacore.adaintellij.editor.BusyEditorAwareOperation
+ */
+public class RunnableOperation extends BusyEditorAwareOperation {
+	
+	/**
+	 * The underlying runnable that is run when this operation
+	 * is executed.
+	 */
+	Runnable runnable;
+	
+	/**
+	 * Constructs a new RunnableOperation given a scheduler and
+	 * a runnable.
+	 *
+	 * @param scheduler The scheduler responsible for the created
+	 *                  operation.
+	 * @param runnable The runnable to run when the created
+	 *                 operation is executed.
+	 */
+	RunnableOperation(
+		@NotNull BusyEditorAwareScheduler scheduler,
+		@NotNull Runnable                 runnable
+	) {
+		super(scheduler);
+		this.runnable = runnable;
+	}
+	
+	/**
+	 * Constructs a new RunnableOperation given a scheduler, a
+	 * merge timeout and a runnable.
+	 * @param scheduler The scheduler responsible for the created
+	 *                  operation.
+	 * @param timeout The merge timeout of the created operation.
+	 * @param runnable The runnable to run when the created
+	 *                 operation is executed.
+	 */
+	RunnableOperation(
+		@NotNull BusyEditorAwareScheduler scheduler,
+		         int                      timeout,
+		@NotNull Runnable                 runnable
+	) {
+		super(scheduler, timeout);
+		this.runnable = runnable;
+	}
+	
+	/**
+	 * Schedules an execution of this runnable operation.
+	 */
+	public void schedule() {
+		
+		// If this operation is not active, then return
+		
+		if (!isActive()) { return; }
+		
+		// Schedule an execution in the internal queue
+		
+		queue.queue(Update.create(this, runnable));
+		
+	}
+	
+}

--- a/src/main/control/com/adacore/adaintellij/lsp/LSPUtils.java
+++ b/src/main/control/com/adacore/adaintellij/lsp/LSPUtils.java
@@ -3,9 +3,11 @@ package com.adacore.adaintellij.lsp;
 import com.intellij.lang.annotation.HighlightSeverity;
 import com.intellij.notification.NotificationType;
 import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.editor.event.DocumentEvent;
 import org.jetbrains.annotations.*;
 
 import org.eclipse.lsp4j.*;
+import org.eclipse.lsp4j.Range;
 
 import static com.adacore.adaintellij.analysis.semantic.AdaPsiElement.AdaElementType;
 
@@ -125,6 +127,38 @@ public final class LSPUtils {
 			default:       return null;
 			
 		}
+		
+	}
+	
+	/**
+	 * Translates the given IntelliJ platform document event to a
+	 * text-document content change event, defined in the LSP
+	 * standard.
+	 *
+	 * @param event The document event to translate.
+	 * @return The corresponding text-document content change event.
+	 */
+	@NotNull
+	public static TextDocumentContentChangeEvent
+		documentEventToContentChangeEvent(@NotNull DocumentEvent event)
+	{
+		
+		Document changedDocument = event.getDocument();
+		
+		TextDocumentContentChangeEvent changeEvent =
+			new TextDocumentContentChangeEvent();
+		
+		int offset    = event.getOffset();
+		int oldLength = event.getOldLength();
+		
+		changeEvent.setRange(new Range(
+			offsetToPosition(changedDocument, offset),
+			offsetToPosition(changedDocument, offset + oldLength)
+		));
+		changeEvent.setRangeLength(oldLength);
+		changeEvent.setText(event.getNewFragment().toString());
+		
+		return changeEvent;
 		
 	}
 	

--- a/src/main/control/com/adacore/adaintellij/lsp/Timeouts.java
+++ b/src/main/control/com/adacore/adaintellij/lsp/Timeouts.java
@@ -12,7 +12,7 @@ public final class Timeouts {
 	/**
 	 * Default request timeout.
 	 */
-	public static final int DEFAULT_METHOD_TIMEOUT = 3000;
+	public static final int DEFAULT_METHOD_TIMEOUT = 4_000;
 	
 	/**
 	 * LSP-method -> timeout mapping.
@@ -25,9 +25,9 @@ public final class Timeouts {
 		
 		Map<String, Integer> methodTimeouts = new HashMap<>();
 		
-		methodTimeouts.put("textDocument/completion", 5000);
-		methodTimeouts.put("textDocument/definition", 2000);
-		methodTimeouts.put("textDocument/references", 5000);
+		methodTimeouts.put("textDocument/completion", 8_000);
+		methodTimeouts.put("textDocument/definition", 4_000);
+		methodTimeouts.put("textDocument/references", 8_000);
 		
 		METHOD_TIMEOUTS = Collections.unmodifiableMap(methodTimeouts);
 	

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -76,6 +76,11 @@
 			<implementation-class>com.adacore.adaintellij.lsp.AdaLSPDriver</implementation-class>
 		</component>
 		
+		<!-- Busy-editor-aware operation scheduler -->
+		<component>
+			<implementation-class>com.adacore.adaintellij.editor.BusyEditorAwareScheduler</implementation-class>
+		</component>
+		
 	</project-components>
 	
 	<!-- Platform extensions -->


### PR DESCRIPTION
The plugin now waits for the editor to become idle before sending LSP `textDocument/didChange` notifications to the server.