### PR TITLE
Updates to the AdaAnnotator

### DIFF
--- a/src/main/control/com/adacore/adaintellij/analysis/syntactic/diagnostics/AdaAnnotator.java
+++ b/src/main/control/com/adacore/adaintellij/analysis/syntactic/diagnostics/AdaAnnotator.java
@@ -23,16 +23,6 @@ import static com.adacore.adaintellij.lsp.LSPUtils.diagnosticSeverityToHighlight
  */
 public class AdaAnnotator extends ExternalAnnotator<List<Diagnostic>, List<Diagnostic>> {
 
-	/**
-	 * Maximum number of attempts to get a document's diagnostics.
-	 */
-	private static final int MAXIMUM_GET_DIAGNOSTICS_ATTEMPTS = 7;
-
-	/**
-	 * The interval duration, in milliseconds, before trying to get
-	 * a document's internally stored diagnostics.
-	 */
-	private static final long GET_DIAGNOSTICS_INTERVAL = 100;
 
 	/**
 	 * @see com.intellij.lang.annotation.ExternalAnnotator#collectInformation(PsiFile)
@@ -54,27 +44,10 @@ public class AdaAnnotator extends ExternalAnnotator<List<Diagnostic>, List<Diagn
 		CacheResult<List<Diagnostic>> cacheResult =
 			Cacher.getCachedData(document, AdaLSPClient.DIAGNOSTICS_CACHE_KEY);
 
-		int attempts = MAXIMUM_GET_DIAGNOSTICS_ATTEMPTS;
 
-		// While the cache read was a miss and the number of attempts
-		// has not reached the maximum number of attempts, sleep for
-		// a short duration of time and try again
-
-		while (!cacheResult.hit) {
-
-			try {
-				Thread.sleep(GET_DIAGNOSTICS_INTERVAL);
-			} catch (InterruptedException exception) {}
-
-			cacheResult = Cacher.getCachedData(document, AdaLSPClient.DIAGNOSTICS_CACHE_KEY);
-
-			attempts--;
-
-			if (attempts == 0) { break; }
-
+		if (! cacheResult.hit) {
+			return null;
 		}
-
-		// Return the last cache read result
 
 		return cacheResult.data;
 
@@ -148,11 +121,12 @@ public class AdaAnnotator extends ExternalAnnotator<List<Diagnostic>, List<Diagn
 
 			// Create an annotation based on the diagnostic data
 
-			holder.createAnnotation(
+			holder.newAnnotation(
 				diagnosticSeverityToHighlightSeverity(severity),
-				new TextRange(startOffset, endOffset),
 				message == null ? severity.name() : message
-			);
+			).range(
+				new TextRange(startOffset, endOffset)
+			).create();
 
 		}
 

--- a/src/main/control/com/adacore/adaintellij/lsp/AdaLSPClient.java
+++ b/src/main/control/com/adacore/adaintellij/lsp/AdaLSPClient.java
@@ -4,8 +4,12 @@ import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import javax.swing.*;
 
+import com.intellij.codeInsight.daemon.DaemonCodeAnalyzer;
+import com.intellij.codeInsight.daemon.impl.DaemonCodeAnalyzerImpl;
+import com.intellij.codeInsight.daemon.impl.HighlightInfo;
 import com.intellij.notification.Notifications;
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.command.WriteCommandAction;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.project.Project;
@@ -252,10 +256,20 @@ public final class AdaLSPClient implements LanguageClient {
 
 		if (document == null) { return; }
 
-		// Store the diagnostics in the document
+		WriteCommandAction.runWriteCommandAction(this.project,() -> {
 
-		Cacher.cacheData(document, DIAGNOSTICS_CACHE_KEY, diagnostics.getDiagnostics());
+			Cacher.cacheData(
+				document,
+				DIAGNOSTICS_CACHE_KEY,
+				diagnostics.getDiagnostics()
+			);
 
+			DaemonCodeAnalyzer.getInstance(this.project).restart(
+				Utils.getVirtualFilePsiFile(
+					this.project, virtualFile
+				)
+			);
+		});
 	}
 
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -6,7 +6,7 @@
 	<name>Ada</name>
 	<vendor email="jetbrains@adacore.com" url="https://www.adacore.com">AdaCore</vendor>
 
-	<idea-version since-build="183.2153.8"/>
+	<idea-version since-build="201.3803.71"/>
 
 	<description><![CDATA[
 		Support for the Ada and SPARK languages, and GPR project files.
@@ -105,7 +105,11 @@
 		<!-- Ada structure view factory -->
 		<lang.psiStructureViewFactory language="Ada" implementationClass="com.adacore.adaintellij.analysis.syntactic.structure.AdaStructureViewFactory"/>
 		<!-- Ada code annotator -->
-		<externalAnnotator language="Ada" implementationClass="com.adacore.adaintellij.analysis.syntactic.diagnostics.AdaAnnotator"/>
+		<externalAnnotator
+			id="com.adacore.adaintellij.analysis.syntactic.diagnostics.AdaAnnotator"
+			language="Ada"
+			implementationClass="com.adacore.adaintellij.analysis.syntactic.diagnostics.AdaAnnotator"
+		/>
 
 		<!-- Ada names validator -->
 		<lang.namesValidator language="Ada" implementationClass="com.adacore.adaintellij.analysis.lexical.AdaNamesValidator"/>


### PR DESCRIPTION
The AdaAnnotator was causing some UI issues by calling Thread.sleep(). As the annotator is called from UI thread this sleep call made the editor feel laggy.
I've added a call to DaemonCodeAnalyzer.getInstance.restart() in AdaLSPClient to re trigger an annotation pass after we receive diagnostics from the ALS

[Here's a video of it in action ](https://youtu.be/FRde9u1O52U)