### PR TITLE
Fix failing folding builder test

### DIFF
--- a/src/test/control/com/adacore/adaintellij/misc/AdaFoldingBuilderTest.java
+++ b/src/test/control/com/adacore/adaintellij/misc/AdaFoldingBuilderTest.java
@@ -40,7 +40,7 @@ public class AdaFoldingBuilderTest extends LightJavaCodeInsightFixtureTestCase {
     @Test
     public void testFolds()
     {
-        myFixture.copyFileToProject( "/project.gpr");
+        myFixture.copyFileToProject( "/test_project.gpr");
 
         myFixture.getProject().getComponent(AdaProject.class).projectOpened();
         myFixture.getProject().getComponent(AdaLSPDriver.class).projectOpened();

--- a/src/test/resources/ada-sources/folding-test-data.ads
+++ b/src/test/resources/ada-sources/folding-test-data.ads
@@ -2,7 +2,7 @@
 with Ada.Text_IO;
 with Pattern_Control;</fold>
 
-<fold text='package Bens_New_Packge is ...' expand='true'>package Bens_New_Packge is
+<fold text='package Bens_New_Package is ...' expand='true'>package Bens_New_Package is
 <fold text='    function test_1 return Integer is ...' expand='true'>    function test_1 return Integer is
     begin
          return  1;
@@ -12,4 +12,4 @@ with Pattern_Control;</fold>
     begin
          return  2;
     End Test_2;</fold>
-end Bens_New_Package</fold>
+end Bens_New_Package;</fold>

--- a/src/test/resources/ada-sources/test_project.gpr
+++ b/src/test/resources/ada-sources/test_project.gpr
@@ -1,0 +1,2 @@
+project Test_Project is
+end Test_Project;


### PR DESCRIPTION
This PR addresses #78.

During the plugin build, the test suite was failing on the `AdaFoldingBuilderTest` case `testFolds()`. The ALS trace logs indicated that this was due to two things:
* Firstly, that a missing semicolon was missing from the `end` statement at the end of the test fixture; and,
* Secondly, that the test project `project.gpr` was invalid and not being parsed, and returning an error state to the plugin.

These issues have been addressed in this PR, and all tests now pass correctly.